### PR TITLE
PAE-1247: Add draft report view to happy path journey tests

### DIFF
--- a/test/specs/accredited.exporter.report.e2e.js
+++ b/test/specs/accredited.exporter.report.e2e.js
@@ -18,6 +18,11 @@ import {
   updateMigratedOrganisation
 } from '../support/apicalls.js'
 import { checkBodyText } from '../support/checks.js'
+import ConfirmationPage from '../page-objects/reports/confirmation.page.js'
+import {
+  switchToNewTab,
+  closeCurrentTabAndReturn
+} from '../support/windowtabs.js'
 
 describe('Accredited exporter report flow @accreditedExporter', () => {
   describe('accredited exporter with upload', () => {
@@ -230,6 +235,23 @@ describe('Accredited exporter report flow @accreditedExporter', () => {
 
       // Verify confirmation page
       await checkBodyText('report created', 30)
+
+      // --- View draft report in new tab ---
+      await ConfirmationPage.viewDraftReport()
+      const originalTab = await switchToNewTab()
+
+      // Verify draft report page content
+      await checkBodyText('Draft report for', 10)
+      await checkBodyText('Ready to submit', 10)
+      await checkBodyText('Created by:', 10)
+      await checkBodyText('Created on:', 10)
+      await checkBodyText('Packaging waste received for exporting', 10)
+      await checkBodyText('Packaging waste exported for recycling', 10)
+      await checkBodyText('Packaging waste sent on', 10)
+      await checkBodyText('Supporting information', 10)
+
+      // Close draft tab and return to confirmation page
+      await closeCurrentTabAndReturn(originalTab)
     })
   })
 

--- a/test/specs/accredited.reprocessor.report.e2e.js
+++ b/test/specs/accredited.reprocessor.report.e2e.js
@@ -20,6 +20,11 @@ import {
   updateMigratedOrganisation
 } from '../support/apicalls.js'
 import { checkBodyText } from '../support/checks.js'
+import ConfirmationPage from '../page-objects/reports/confirmation.page.js'
+import {
+  switchToNewTab,
+  closeCurrentTabAndReturn
+} from '../support/windowtabs.js'
 
 const REG_NUMBER = 'R25SR500010912PA'
 const ACC_NUMBER = 'R-ACC12145PA'
@@ -296,6 +301,27 @@ describe('Accredited reprocessor report flow @accreditedReprocessor', () => {
 
       // Verify confirmation page
       await checkBodyText('report created', 30)
+
+      // --- View draft report in new tab ---
+      await ConfirmationPage.viewDraftReport()
+      const originalTab = await switchToNewTab()
+
+      // Verify draft report page content
+      await checkBodyText('Draft report for', 10)
+      await checkBodyText('Ready to submit', 10)
+      await checkBodyText('Created by:', 10)
+      await checkBodyText('Created on:', 10)
+      await checkBodyText('Packaging waste received for reprocessing', 10)
+      await checkBodyText('Packaging waste recycling', 10)
+      await checkBodyText('Packaging waste sent on', 10)
+      await checkBodyText('Supporting information', 10)
+
+      // Verify the tonnage values from the report
+      await checkBodyText('15.02', 5)
+      await checkBodyText('89.31', 5)
+
+      // Close draft tab and return to confirmation page
+      await closeCurrentTabAndReturn(originalTab)
     })
   })
 

--- a/test/support/windowtabs.js
+++ b/test/support/windowtabs.js
@@ -19,3 +19,23 @@ export async function switchToNewTabAndClosePreviousTab() {
   // Switch back to the new tab (now the only one)
   await browser.switchToWindow(newWindow)
 }
+
+export async function switchToNewTab() {
+  const originalWindow = await browser.getWindowHandle()
+
+  await browser.waitUntil(
+    async () => (await browser.getWindowHandles()).length === 2,
+    { timeout: 5000, timeoutMsg: 'New tab did not open' }
+  )
+
+  const handles = await browser.getWindowHandles()
+  const newWindow = handles.find((handle) => handle !== originalWindow)
+  await browser.switchToWindow(newWindow)
+
+  return originalWindow
+}
+
+export async function closeCurrentTabAndReturn(originalWindow) {
+  await browser.closeWindow()
+  await browser.switchToWindow(originalWindow)
+}


### PR DESCRIPTION
Ticket: [PAE-1247](https://eaflood.atlassian.net/browse/PAE-1247)
## Summary

- Extend the accredited reprocessor and exporter full flow journey tests to verify the draft report view after report creation
- Add `switchToNewTab` and `closeCurrentTabAndReturn` window tab helpers for new-tab verification patterns (complementing the existing `switchToNewTabAndClosePreviousTab`)

## Changes

**test/support/windowtabs.js** — Added two new helpers: `switchToNewTab()` switches to a newly opened tab and returns the original window handle; `closeCurrentTabAndReturn(originalWindow)` closes the current tab and switches back.

**test/specs/accredited.reprocessor.report.e2e.js** — Extended the full flow test to click "View draft report" on the confirmation page, switch to the new tab, and verify: draft heading, "Ready to submit" status, "Created by/on" labels, reprocessor-specific sections (waste received for reprocessing, packaging waste recycling, waste sent on), tonnage values, and supporting information. Closes the draft tab and returns to the confirmation page before signing out.

**test/specs/accredited.exporter.report.e2e.js** — Same pattern for the exporter flow, verifying exporter-specific sections (waste received for exporting, waste exported for recycling).

## Depends on

- https://github.com/DEFRA/epr-frontend/pull/740 (frontend implementation)

[PAE-1247]: https://eaflood.atlassian.net/browse/PAE-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ