### PR TITLE
PAE-1303: Fix seedOverseasSites auth for test environment

### DIFF
--- a/test/support/apicalls.js
+++ b/test/support/apicalls.js
@@ -6,7 +6,6 @@ import {
 
 import { fakerEN_GB } from '@faker-js/faker'
 import { expect } from '@wdio/globals'
-import { FormData } from 'undici'
 import { EprBackend } from '../apis/epr-backend.js'
 import config from '../config/config.js'
 import { AuthClient } from './auth.js'
@@ -172,23 +171,7 @@ export async function updateMigratedOrganisation(
   const authClient = new AuthClient()
   const eprBackend = new EprBackend()
 
-  let payload, urlSuffix
-  if (process.env.ENVIRONMENT === 'test') {
-    payload = new FormData()
-    payload.append('client_id', config.auth.clientId)
-    payload.append('client_secret', config.auth.clientSecret)
-    payload.append('username', config.auth.username)
-    payload.append('password', config.auth.password)
-    payload.append('scope', config.auth.scope)
-    payload.append('grant_type', config.auth.grantType)
-    urlSuffix = ''
-  } else {
-    const clientId = 'clientId'
-    const username = 'ea@test.gov.uk'
-    payload = JSON.stringify({ clientId, username })
-    urlSuffix = '/sign'
-  }
-  await authClient.generateToken(payload, urlSuffix)
+  await authClient.authenticate()
 
   const timeout = 5000
   const startTime = Date.now()
@@ -398,10 +381,7 @@ export async function seedOverseasSites(orgRefNo, registrationIndex = 0) {
   const authClient = new AuthClient()
   const eprBackend = new EprBackend()
 
-  const clientId = 'clientId'
-  const username = 'ea@test.gov.uk'
-  const payload = JSON.stringify({ clientId, username })
-  await authClient.generateToken(payload, '/sign')
+  await authClient.authenticate()
 
   const siteResponse = await eprBackend.post(
     '/v1/overseas-sites',

--- a/test/support/auth.js
+++ b/test/support/auth.js
@@ -1,10 +1,30 @@
 import config from '../config/config.js'
-import { request } from 'undici'
+import { FormData, request } from 'undici'
 
 export class AuthClient {
   constructor(baseUrl = config.authUri) {
     this.baseUrl = baseUrl
     this.defaultHeaders = config.apiHeaders
+  }
+
+  async authenticate() {
+    let payload, urlSuffix
+    if (process.env.ENVIRONMENT === 'test') {
+      payload = new FormData()
+      payload.append('client_id', config.auth.clientId)
+      payload.append('client_secret', config.auth.clientSecret)
+      payload.append('username', config.auth.username)
+      payload.append('password', config.auth.password)
+      payload.append('scope', config.auth.scope)
+      payload.append('grant_type', config.auth.grantType)
+      urlSuffix = ''
+    } else {
+      const clientId = 'clientId'
+      const username = 'ea@test.gov.uk'
+      payload = JSON.stringify({ clientId, username })
+      urlSuffix = '/sign'
+    }
+    await this.generateToken(payload, urlSuffix)
   }
 
   async generateToken(payload, suffix) {


### PR DESCRIPTION
Ticket: [PAE-1303](https://eaflood.atlassian.net/browse/PAE-1303)
## Summary

- `seedOverseasSites` was using the local dev auth path (JSON + `/sign` suffix) unconditionally, which fails on the CDP test environment where Entra requires FormData with client credentials to Microsoft's OAuth endpoint
- This caused the "Unexpected end of JSON input" error on every CDP run for `issue.and.reject.prn.exporter.e2e.js`
- Centralised the environment-aware auth logic into `AuthClient.authenticate()` so both `updateMigratedOrganisation` and `seedOverseasSites` use the same path — consistent with how `CognitoAuth` already handles this

## Test plan

- [ ] Merge and verify the CDP test suite run passes (all 7 smoketest specs green)
- [ ] Verify local dev tests still pass (`npm run test:local` or via Docker Compose)

[PAE-1303]: https://eaflood.atlassian.net/browse/PAE-1303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ