### PR TITLE
PAE-1303: Fix CI test stability — race condition and timeouts

### DIFF
--- a/test/page-objects/dashboard.page.js
+++ b/test/page-objects/dashboard.page.js
@@ -13,7 +13,7 @@ class DashboardPage {
     const linkElement = await $(
       '#main-content table.govuk-table tr:nth-child(' + index + ') a.govuk-link'
     )
-    await linkElement.waitForExist({ timeout: 5000 })
+    await linkElement.waitForExist({ timeout: 10000 })
     await linkElement.click()
   }
 
@@ -25,7 +25,7 @@ class DashboardPage {
         index +
         ') a.govuk-link'
     )
-    await linkElement.waitForExist({ timeout: 5000 })
+    await linkElement.waitForExist({ timeout: 10000 })
     await linkElement.click()
   }
 
@@ -35,7 +35,7 @@ class DashboardPage {
         index +
         ') > td.govuk-table__cell.govuk-table__cell--numeric'
     )
-    await wasteBalanceElement.waitForExist({ timeout: 5000 })
+    await wasteBalanceElement.waitForExist({ timeout: 10000 })
     return await wasteBalanceElement.getText()
   }
 
@@ -51,7 +51,7 @@ class DashboardPage {
         rowIndex +
         ') > td:nth-child(1)'
     )
-    await materialElement.waitForExist({ timeout: 5000 })
+    await materialElement.waitForExist({ timeout: 10000 })
     return await materialElement.getText()
   }
 

--- a/test/page-objects/defra.id.stub.page.js
+++ b/test/page-objects/defra.id.stub.page.js
@@ -38,7 +38,9 @@ class DefraIdStubPage {
   }
 
   async loginViaEmail(email) {
-    await $(`//tr[th[text()="${email}"]]//a`).click()
+    const loginLink = await $(`//tr[th[text()="${email}"]]//a`)
+    await loginLink.waitForExist({ timeout: 15000 })
+    await loginLink.click()
   }
 
   async selectOrganisation(index) {

--- a/test/page-objects/defra.id.stub.page.js
+++ b/test/page-objects/defra.id.stub.page.js
@@ -38,9 +38,17 @@ class DefraIdStubPage {
   }
 
   async loginViaEmail(email) {
-    const loginLink = await $(`//tr[th[text()="${email}"]]//a`)
-    await loginLink.waitForExist({ timeout: 15000 })
-    await loginLink.click()
+    const selector = `//tr[th[text()="${email}"]]//a`
+    await browser.waitUntil(
+      async () => {
+        const el = await $(selector)
+        if (await el.isExisting()) return true
+        await browser.refresh()
+        return false
+      },
+      { timeout: 15000, interval: 2000 }
+    )
+    await $(selector).click()
   }
 
   async selectOrganisation(index) {

--- a/wdio.github.conf.js
+++ b/wdio.github.conf.js
@@ -67,6 +67,7 @@ export const config = {
   connectionRetryCount: 3,
 
   framework: 'mocha',
+  specFileRetries: 1,
 
   reporters: [
     [


### PR DESCRIPTION
Ticket: [PAE-1303](https://eaflood.atlassian.net/browse/PAE-1303)

## Summary
- Fix DefraID stub login race condition in `loginViaEmail`
- Increase `DashboardPage` element wait timeouts from 5s to 10s
- Add `specFileRetries: 1` as a safety net for remaining transient failures

## Root cause analysis

Sampled 10 recent CI failures from the Check Pull Request workflow (excluding Dependabot):

| Pattern | Frequency | Cause |
|---|---|---|
| DefraID stub login race condition | 7/10 | Tests register a user via API, then immediately navigate to the stub login page and click the user's row by email XPath. `loginViaEmail` had no `waitForExist` — just a raw selector click. Under CI parallelism (5 instances), the stub page renders before the registration is fully processed. |
| Tight 5s element waits | 4/10 | `DashboardPage` methods use `waitForExist({ timeout: 5000 })` which is too short when 5 browser instances compete for CPU on a 2-vCPU GitHub Actions runner. |
| Upload/processing timeouts | 2/10 | Intermittent — the backend occasionally takes longer than 30s to process an uploaded spreadsheet. |
| DefraID stub auth error on Docker image change | 1/10 | One-off — invalid user selection after a container image update. |

(Some failures exhibited multiple patterns.)

## Changes

### 1. `defra.id.stub.page.js` — Fix race condition (Pattern 1)

The stub login page is server-rendered — the user list is baked into the HTML at render time. A simple `waitForExist` would just poll a static DOM where the email row will never appear. Instead, we use a `waitUntil` loop that **refreshes the page every 2s**, giving the stub a chance to re-render with the newly registered user. Times out after 15s.

### 2. `dashboard.page.js` — Increase wait timeouts (Pattern 2)

Bumped all four `waitForExist` calls from 5000ms to 10000ms. Unlike the stub login page, the dashboard elements are present in the server response — the browser just needs time to load and render under CI load. `waitForExist` is appropriate here because the DOM _will_ contain the elements once the page finishes loading. The 5s timeout was too tight; 10s matches the global `waitforTimeout` already set in the wdio config.

### 3. `wdio.github.conf.js` — Add spec file retries (Patterns 3 & 4)

Added `specFileRetries: 1` to automatically retry a failed spec file once. This catches the remaining transient failures (upload timeouts, one-off auth errors) that can't be fixed by tighter waits alone. The setting was already present but commented out in `wdio.local.conf.js`.

## Test plan
- [x] CI pipeline passes on this PR
- [ ] Monitor next 10 CI runs for reduced flakiness

[PAE-1303]: https://eaflood.atlassian.net/browse/PAE-1303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ