### PR TITLE
PAE-1303: Share setup across accredited report tests to cut runtime

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,12 @@ for (const item of ns) {
 export default [
   ...ns,
   {
+    languageOptions: {
+      globals: {
+        before: 'readonly',
+        after: 'readonly'
+      }
+    },
     rules: {
       camelcase: [
         'error',

--- a/test/specs/accredited.exporter.report.e2e.js
+++ b/test/specs/accredited.exporter.report.e2e.js
@@ -20,444 +20,291 @@ import {
 import { checkBodyText } from '../support/checks.js'
 
 describe('Accredited exporter report flow @accreditedExporter', () => {
-  it('should navigate back correctly through the accredited exporter flow @accreditedExporterBackLinks', async () => {
-    const regNumber = 'E25SR500020912PA'
-    const accNumber = 'E-ACC12245PA'
+  describe('accredited exporter with upload', () => {
+    before(async () => {
+      const regNumber = 'E25SR500020912PA'
+      const accNumber = 'E-ACC12245PA'
 
-    const organisationDetails = await createLinkedOrganisation([
-      {
-        material: 'Paper or board (R3)',
-        wasteProcessingType: 'Exporter'
-      }
-    ])
-
-    const migrationResponse = await updateMigratedOrganisation(
-      organisationDetails.refNo,
-      [
+      const organisationDetails = await createLinkedOrganisation([
         {
-          regNumber,
-          accNumber,
-          status: 'approved'
+          material: 'Paper or board (R3)',
+          wasteProcessingType: 'Exporter'
         }
-      ]
-    )
+      ])
 
-    const user = await createAndRegisterDefraIdUser(migrationResponse.email)
-    await linkDefraIdUser(
-      organisationDetails.refNo,
-      user.userId,
-      migrationResponse.email
-    )
+      const migrationResponse = await updateMigratedOrganisation(
+        organisationDetails.refNo,
+        [
+          {
+            regNumber,
+            accNumber,
+            status: 'approved'
+          }
+        ]
+      )
 
-    await HomePage.openStart()
-    await HomePage.clickStartNow()
-    await DefraIdStubPage.loginViaEmail(migrationResponse.email)
+      const user = await createAndRegisterDefraIdUser(migrationResponse.email)
+      await linkDefraIdUser(
+        organisationDetails.refNo,
+        user.userId,
+        migrationResponse.email
+      )
 
-    // Upload summary log
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.submitSummaryLogLink()
+      await HomePage.openStart()
+      await HomePage.clickStartNow()
+      await DefraIdStubPage.loginViaEmail(migrationResponse.email)
 
-    const filePath = `resources/sanity/exporter_${accNumber}_${regNumber}.xlsx`
-    await UploadSummaryLogPage.performUploadAndReturnToHomepage(filePath)
+      // Upload summary log so report data exists
+      await DashboardPage.selectTableLink(1, 1)
+      await WasteRecordsPage.submitSummaryLogLink()
 
-    // Navigate to reports and start report
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.manageReportsLink()
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
+      const filePath = `resources/sanity/exporter_${accNumber}_${regNumber}.xlsx`
+      await UploadSummaryLogPage.performUploadAndReturnToHomepage(filePath)
 
-    // On prn-summary — back link goes to detail page
-    await PrnSummaryPage.selectBackLink()
-    const detailHeading = await ReportDetailPage.headingText()
-    expect(detailHeading).toBeTruthy()
+      // Navigate to reports — all tests start from the Reports page
+      await DashboardPage.selectTableLink(1, 1)
+      await WasteRecordsPage.manageReportsLink()
+    })
 
-    // Go forward again
-    await ReportDetailPage.useThisData()
+    after(async () => {
+      await HomePage.signOut()
+      await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+    })
 
-    // Continue to free-perns
-    await PrnSummaryPage.enterRevenue('100')
-    await PrnSummaryPage.continue()
+    it('should navigate back correctly through the accredited exporter flow @accreditedExporterBackLinks', async () => {
+      await ReportsPage.selectActionLink(1)
+      await ReportDetailPage.useThisData()
 
-    // On free-perns — back link goes to prn-summary
-    await FreePernPage.selectBackLink()
-    const backToPrnSummary = await PrnSummaryPage.headingText()
-    expect(backToPrnSummary).toBeTruthy()
+      // On prn-summary — back link goes to detail page
+      await PrnSummaryPage.selectBackLink()
+      const detailHeading = await ReportDetailPage.headingText()
+      expect(detailHeading).toBeTruthy()
 
-    // Continue through to supporting info
-    await PrnSummaryPage.enterRevenue('100')
-    await PrnSummaryPage.continue()
-    await FreePernPage.enterTonnage('0')
-    await FreePernPage.continue()
+      // Go forward again
+      await ReportDetailPage.useThisData()
 
-    // On supporting info — back link goes to free-perns
-    await ReportSupportingInformationPage.selectBackLink()
-    const backToFreePern = await FreePernPage.headingText()
-    expect(backToFreePern).toBeTruthy()
+      // Continue to free-perns
+      await PrnSummaryPage.enterRevenue('100')
+      await PrnSummaryPage.continue()
 
-    // Clean up
-    await FreePernPage.deleteReportLink()
-    await ConfirmDeleteReportPage.confirmDeletion()
+      // On free-perns — back link goes to prn-summary
+      await FreePernPage.selectBackLink()
+      const backToPrnSummary = await PrnSummaryPage.headingText()
+      expect(backToPrnSummary).toBeTruthy()
 
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+      // Continue through to supporting info
+      await PrnSummaryPage.enterRevenue('100')
+      await PrnSummaryPage.continue()
+      await FreePernPage.enterTonnage('0')
+      await FreePernPage.continue()
+
+      // On supporting info — back link goes to free-perns
+      await ReportSupportingInformationPage.selectBackLink()
+      const backToFreePern = await FreePernPage.headingText()
+      expect(backToFreePern).toBeTruthy()
+
+      // Clean up — delete report so next test starts fresh
+      await FreePernPage.deleteReportLink()
+      await ConfirmDeleteReportPage.confirmDeletion()
+    })
+
+    it('should navigate to delete confirmation from PRN summary and free PERNs pages @accreditedExporterDelete', async () => {
+      await ReportsPage.selectActionLink(1)
+      await ReportDetailPage.useThisData()
+
+      // --- Delete from PRN summary page ---
+      await PrnSummaryPage.deleteReportLink()
+
+      const deleteHeading = await ConfirmDeleteReportPage.headingText()
+      expect(deleteHeading).toBe('Confirm deletion of this report')
+
+      // Back link should return to prn-summary
+      await ConfirmDeleteReportPage.selectBackLink()
+      const backToPrnSummary = await PrnSummaryPage.headingText()
+      expect(backToPrnSummary).toBeTruthy()
+
+      // Confirm deletion
+      await PrnSummaryPage.deleteReportLink()
+      await ConfirmDeleteReportPage.confirmDeletion()
+
+      // Should be back on reports list with status reverted to Due
+      let reportsHeading = await ReportsPage.headingText()
+      expect(reportsHeading).toContain('Reports')
+
+      let statusBadge = await ReportsPage.getStatusBadge(1)
+      expect(statusBadge).toBe('Due')
+
+      // --- Create report again, navigate to free-perns, delete from there ---
+      await ReportsPage.selectActionLink(1)
+      await ReportDetailPage.useThisData()
+      await PrnSummaryPage.enterRevenue('100')
+      await PrnSummaryPage.continue()
+
+      await FreePernPage.deleteReportLink()
+
+      const deleteHeading2 = await ConfirmDeleteReportPage.headingText()
+      expect(deleteHeading2).toBe('Confirm deletion of this report')
+
+      await ConfirmDeleteReportPage.confirmDeletion()
+
+      // Should be back on reports list with status reverted to Due
+      reportsHeading = await ReportsPage.headingText()
+      expect(reportsHeading).toContain('Reports')
+
+      statusBadge = await ReportsPage.getStatusBadge(1)
+      expect(statusBadge).toBe('Due')
+    })
+
+    it('should save and come back later from PRN summary and free PERNs pages @accreditedExporterSave', async () => {
+      await ReportsPage.selectActionLink(1)
+      await ReportDetailPage.useThisData()
+
+      // --- Save from PRN summary page ---
+      await PrnSummaryPage.enterRevenue('500')
+      await PrnSummaryPage.saveAndComeBackLater()
+
+      // Should redirect back to reports list
+      const reportsHeading = await ReportsPage.headingText()
+      expect(reportsHeading).toContain('Reports')
+
+      // Resume the report — Continue goes directly to prn-summary for accredited exporters
+      await ReportsPage.selectActionLink(1)
+
+      // Continue past prn-summary to free-perns
+      await PrnSummaryPage.enterRevenue('500')
+      await PrnSummaryPage.continue()
+
+      // --- Save from free PERNs page ---
+      await FreePernPage.enterTonnage('0')
+      await FreePernPage.saveAndComeBackLater()
+
+      // Should redirect back to reports list
+      const reportsHeadingAfterSave = await ReportsPage.headingText()
+      expect(reportsHeadingAfterSave).toContain('Reports')
+
+      // Clean up — delete the report (Continue goes directly to prn-summary)
+      await ReportsPage.selectActionLink(1)
+      await PrnSummaryPage.deleteReportLink()
+      await ConfirmDeleteReportPage.confirmDeletion()
+    })
+
+    it('should complete the full accredited exporter report flow through to confirmation @accreditedExporterFullFlow', async () => {
+      await ReportsPage.selectActionLink(1)
+      await ReportDetailPage.useThisData()
+
+      // --- PRN Summary page ---
+      const prnSummaryHeading = await PrnSummaryPage.headingText()
+      expect(prnSummaryHeading).toBeTruthy()
+
+      // Enter revenue
+      await PrnSummaryPage.enterRevenue('1500.50')
+      await PrnSummaryPage.continue()
+
+      // --- Free PERNs page ---
+      const freePernHeading = await FreePernPage.headingText()
+      expect(freePernHeading).toBeTruthy()
+
+      // Enter free PERN tonnage (must be <= issued tonnage)
+      await FreePernPage.enterTonnage('0')
+      await FreePernPage.continue()
+
+      // --- Supporting information page ---
+      const supportingInfoHeading =
+        await ReportSupportingInformationPage.headingText()
+      expect(supportingInfoHeading).toBe(
+        'Add supporting information for your regulator (optional)'
+      )
+      await ReportSupportingInformationPage.continue()
+
+      // --- Check your answers page ---
+      const checkHeading = await ReportCheckAnswersPage.headingText()
+      expect(checkHeading).toBe(
+        'Check your answers before creating draft report'
+      )
+
+      // Verify PRN revenue persists to CYA
+      await checkBodyText('1,500.50', 10)
+
+      // Submit the report
+      await ReportCheckAnswersPage.createReport()
+
+      // Verify confirmation page
+      await checkBodyText('report created', 30)
+    })
   })
 
-  it('should navigate to delete confirmation from PRN summary and free PERNs pages @accreditedExporterDelete', async () => {
-    const regNumber = 'E25SR500020912PA'
-    const accNumber = 'E-ACC12245PA'
+  describe('non-accredited exporter route guards', () => {
+    let orgRefNo
+    let registrationId
 
-    const organisationDetails = await createLinkedOrganisation([
-      {
-        material: 'Paper or board (R3)',
-        wasteProcessingType: 'Exporter'
-      }
-    ])
-
-    const migrationResponse = await updateMigratedOrganisation(
-      organisationDetails.refNo,
-      [
+    before(async () => {
+      const organisationDetails = await createLinkedOrganisation([
         {
-          regNumber,
-          accNumber,
-          status: 'approved'
-        }
-      ]
-    )
-
-    const user = await createAndRegisterDefraIdUser(migrationResponse.email)
-    await linkDefraIdUser(
-      organisationDetails.refNo,
-      user.userId,
-      migrationResponse.email
-    )
-
-    await HomePage.openStart()
-    await HomePage.clickStartNow()
-    await DefraIdStubPage.loginViaEmail(migrationResponse.email)
-
-    // Upload summary log
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.submitSummaryLogLink()
-
-    const filePath = `resources/sanity/exporter_${accNumber}_${regNumber}.xlsx`
-    await UploadSummaryLogPage.performUploadAndReturnToHomepage(filePath)
-
-    // Navigate to reports and start report
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.manageReportsLink()
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
-
-    // --- Delete from PRN summary page ---
-    await PrnSummaryPage.deleteReportLink()
-
-    const deleteHeading = await ConfirmDeleteReportPage.headingText()
-    expect(deleteHeading).toBe('Confirm deletion of this report')
-
-    // Back link should return to prn-summary
-    await ConfirmDeleteReportPage.selectBackLink()
-    const backToPrnSummary = await PrnSummaryPage.headingText()
-    expect(backToPrnSummary).toBeTruthy()
-
-    // Confirm deletion
-    await PrnSummaryPage.deleteReportLink()
-    await ConfirmDeleteReportPage.confirmDeletion()
-
-    // Should be back on reports list with status reverted to Due
-    let reportsHeading = await ReportsPage.headingText()
-    expect(reportsHeading).toContain('Reports')
-
-    let statusBadge = await ReportsPage.getStatusBadge(1)
-    expect(statusBadge).toBe('Due')
-
-    // --- Create report again, navigate to free-perns, delete from there ---
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
-    await PrnSummaryPage.enterRevenue('100')
-    await PrnSummaryPage.continue()
-
-    await FreePernPage.deleteReportLink()
-
-    const deleteHeading2 = await ConfirmDeleteReportPage.headingText()
-    expect(deleteHeading2).toBe('Confirm deletion of this report')
-
-    await ConfirmDeleteReportPage.confirmDeletion()
-
-    // Should be back on reports list with status reverted to Due
-    reportsHeading = await ReportsPage.headingText()
-    expect(reportsHeading).toContain('Reports')
-
-    statusBadge = await ReportsPage.getStatusBadge(1)
-    expect(statusBadge).toBe('Due')
-
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
-  })
-
-  it('should save and come back later from PRN summary and free PERNs pages @accreditedExporterSave', async () => {
-    const regNumber = 'E25SR500020912PA'
-    const accNumber = 'E-ACC12245PA'
-
-    const organisationDetails = await createLinkedOrganisation([
-      {
-        material: 'Paper or board (R3)',
-        wasteProcessingType: 'Exporter'
-      }
-    ])
-
-    const migrationResponse = await updateMigratedOrganisation(
-      organisationDetails.refNo,
-      [
-        {
-          regNumber,
-          accNumber,
-          status: 'approved'
-        }
-      ]
-    )
-
-    const user = await createAndRegisterDefraIdUser(migrationResponse.email)
-    await linkDefraIdUser(
-      organisationDetails.refNo,
-      user.userId,
-      migrationResponse.email
-    )
-
-    await HomePage.openStart()
-    await HomePage.clickStartNow()
-    await DefraIdStubPage.loginViaEmail(migrationResponse.email)
-
-    // Upload summary log
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.submitSummaryLogLink()
-
-    const filePath = `resources/sanity/exporter_${accNumber}_${regNumber}.xlsx`
-    await UploadSummaryLogPage.performUploadAndReturnToHomepage(filePath)
-
-    // Navigate to reports and start report
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.manageReportsLink()
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
-
-    // --- Save from PRN summary page ---
-    await PrnSummaryPage.enterRevenue('500')
-    await PrnSummaryPage.saveAndComeBackLater()
-
-    // Should redirect back to reports list
-    const reportsHeading = await ReportsPage.headingText()
-    expect(reportsHeading).toContain('Reports')
-
-    // Resume the report — Continue goes directly to prn-summary for accredited exporters
-    await ReportsPage.selectActionLink(1)
-
-    // Continue past prn-summary to free-perns
-    await PrnSummaryPage.enterRevenue('500')
-    await PrnSummaryPage.continue()
-
-    // --- Save from free PERNs page ---
-    await FreePernPage.enterTonnage('0')
-    await FreePernPage.saveAndComeBackLater()
-
-    // Should redirect back to reports list
-    const reportsHeadingAfterSave = await ReportsPage.headingText()
-    expect(reportsHeadingAfterSave).toContain('Reports')
-
-    // Clean up — delete the report (Continue goes directly to prn-summary)
-    await ReportsPage.selectActionLink(1)
-    await PrnSummaryPage.deleteReportLink()
-    await ConfirmDeleteReportPage.confirmDeletion()
-
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
-  })
-
-  it('should complete the full accredited exporter report flow through to confirmation @accreditedExporterFullFlow', async () => {
-    const regNumber = 'E25SR500020912PA'
-    const accNumber = 'E-ACC12245PA'
-
-    const organisationDetails = await createLinkedOrganisation([
-      {
-        material: 'Paper or board (R3)',
-        wasteProcessingType: 'Exporter'
-      }
-    ])
-
-    const migrationResponse = await updateMigratedOrganisation(
-      organisationDetails.refNo,
-      [
-        {
-          regNumber,
-          accNumber,
-          status: 'approved'
-        }
-      ]
-    )
-
-    const user = await createAndRegisterDefraIdUser(migrationResponse.email)
-    await linkDefraIdUser(
-      organisationDetails.refNo,
-      user.userId,
-      migrationResponse.email
-    )
-
-    await HomePage.openStart()
-    await HomePage.clickStartNow()
-    await DefraIdStubPage.loginViaEmail(migrationResponse.email)
-
-    // Upload summary log so report data exists
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.submitSummaryLogLink()
-
-    const filePath = `resources/sanity/exporter_${accNumber}_${regNumber}.xlsx`
-    await UploadSummaryLogPage.performUploadAndReturnToHomepage(filePath)
-
-    // Navigate to reports
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.manageReportsLink()
-
-    // Start the report — should redirect to prn-summary for accredited exporter
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
-
-    // --- PRN Summary page ---
-    const prnSummaryHeading = await PrnSummaryPage.headingText()
-    expect(prnSummaryHeading).toBeTruthy()
-
-    // Enter revenue
-    await PrnSummaryPage.enterRevenue('1500.50')
-    await PrnSummaryPage.continue()
-
-    // --- Free PERNs page ---
-    const freePernHeading = await FreePernPage.headingText()
-    expect(freePernHeading).toBeTruthy()
-
-    // Enter free PERN tonnage (must be <= issued tonnage)
-    await FreePernPage.enterTonnage('0')
-    await FreePernPage.continue()
-
-    // --- Supporting information page ---
-    const supportingInfoHeading =
-      await ReportSupportingInformationPage.headingText()
-    expect(supportingInfoHeading).toBe(
-      'Add supporting information for your regulator (optional)'
-    )
-    await ReportSupportingInformationPage.continue()
-
-    // --- Check your answers page ---
-    const checkHeading = await ReportCheckAnswersPage.headingText()
-    expect(checkHeading).toBe('Check your answers before creating draft report')
-
-    // Verify PRN revenue persists to CYA
-    await checkBodyText('1,500.50', 10)
-
-    // Submit the report
-    await ReportCheckAnswersPage.createReport()
-
-    // Verify confirmation page
-    await checkBodyText('report created', 30)
-
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
-  })
-
-  it('should return 404 when non-accredited exporter tries to access PRN pages @accreditedExporterRouteGuard', async () => {
-    const regNumber = 'E25SR500050912PA'
-
-    const organisationDetails = await createLinkedOrganisation([
-      {
-        material: 'Paper or board (R3)',
-        wasteProcessingType: 'Exporter',
-        withoutAccreditation: true
-      }
-    ])
-
-    const migrationResponse = await updateMigratedOrganisation(
-      organisationDetails.refNo,
-      [
-        {
-          regNumber,
-          status: 'approved',
+          material: 'Paper or board (R3)',
+          wasteProcessingType: 'Exporter',
           withoutAccreditation: true
         }
-      ]
-    )
+      ])
 
-    const user = await createAndRegisterDefraIdUser(migrationResponse.email)
-    await linkDefraIdUser(
-      organisationDetails.refNo,
-      user.userId,
-      migrationResponse.email
-    )
+      const migrationResponse = await updateMigratedOrganisation(
+        organisationDetails.refNo,
+        [
+          {
+            regNumber: 'E25SR500050912PA',
+            status: 'approved',
+            withoutAccreditation: true
+          }
+        ]
+      )
 
-    await HomePage.openStart()
-    await HomePage.clickStartNow()
-    await DefraIdStubPage.loginViaEmail(migrationResponse.email)
+      const user = await createAndRegisterDefraIdUser(migrationResponse.email)
+      await linkDefraIdUser(
+        organisationDetails.refNo,
+        user.userId,
+        migrationResponse.email
+      )
 
-    // Try to access prn-summary directly — should get 404
-    await browser.url(
-      `/organisations/${organisationDetails.refNo}/registrations/${migrationResponse.registrationIds[0]}/reports/2026/monthly/1/prn-summary`
-    )
-    await checkBodyText('404', 10)
-    await checkBodyText('Page not found', 10)
+      orgRefNo = organisationDetails.refNo
+      registrationId = migrationResponse.registrationIds[0]
 
-    // Try to access free-perns directly — should get 404
-    await browser.url(
-      `/organisations/${organisationDetails.refNo}/registrations/${migrationResponse.registrationIds[0]}/reports/2026/monthly/1/free-perns`
-    )
-    await checkBodyText('404', 10)
-    await checkBodyText('Page not found', 10)
+      await HomePage.openStart()
+      await HomePage.clickStartNow()
+      await DefraIdStubPage.loginViaEmail(migrationResponse.email)
+    })
 
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
-  })
+    after(async () => {
+      await HomePage.signOut()
+      await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+    })
 
-  it('should return 404 when registered-only exporter tries to access PRN pages @registeredOnlyExporterRegression', async () => {
-    const regNumber = 'E25SR500030913PA'
+    it('should return 404 when non-accredited exporter tries to access PRN pages @accreditedExporterRouteGuard', async () => {
+      // Try to access prn-summary directly — should get 404
+      await browser.url(
+        `/organisations/${orgRefNo}/registrations/${registrationId}/reports/2026/monthly/1/prn-summary`
+      )
+      await checkBodyText('404', 10)
+      await checkBodyText('Page not found', 10)
 
-    const organisationDetails = await createLinkedOrganisation([
-      {
-        material: 'Paper or board (R3)',
-        wasteProcessingType: 'Exporter',
-        withoutAccreditation: true
-      }
-    ])
+      // Try to access free-perns directly — should get 404
+      await browser.url(
+        `/organisations/${orgRefNo}/registrations/${registrationId}/reports/2026/monthly/1/free-perns`
+      )
+      await checkBodyText('404', 10)
+      await checkBodyText('Page not found', 10)
+    })
 
-    const migrationResponse = await updateMigratedOrganisation(
-      organisationDetails.refNo,
-      [
-        {
-          regNumber,
-          status: 'approved',
-          withoutAccreditation: true
-        }
-      ]
-    )
+    it('should return 404 when registered-only exporter tries to access PRN pages @registeredOnlyExporterRegression', async () => {
+      // Try to access prn-summary directly — should get 404
+      await browser.url(
+        `/organisations/${orgRefNo}/registrations/${registrationId}/reports/2026/monthly/1/prn-summary`
+      )
+      await checkBodyText('Page not found', 10)
 
-    const user = await createAndRegisterDefraIdUser(migrationResponse.email)
-    await linkDefraIdUser(
-      organisationDetails.refNo,
-      user.userId,
-      migrationResponse.email
-    )
-
-    await HomePage.openStart()
-    await HomePage.clickStartNow()
-    await DefraIdStubPage.loginViaEmail(migrationResponse.email)
-
-    // Try to access prn-summary directly — should get 404
-    await browser.url(
-      `/organisations/${organisationDetails.refNo}/registrations/${migrationResponse.registrationIds[0]}/reports/2026/monthly/1/prn-summary`
-    )
-    await checkBodyText('Page not found', 10)
-
-    // Try to access free-perns directly — should get 404
-    await browser.url(
-      `/organisations/${organisationDetails.refNo}/registrations/${migrationResponse.registrationIds[0]}/reports/2026/monthly/1/free-perns`
-    )
-    await checkBodyText('Page not found', 10)
-
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+      // Try to access free-perns directly — should get 404
+      await browser.url(
+        `/organisations/${orgRefNo}/registrations/${registrationId}/reports/2026/monthly/1/free-perns`
+      )
+      await checkBodyText('Page not found', 10)
+    })
   })
 })

--- a/test/specs/accredited.exporter.report.e2e.js
+++ b/test/specs/accredited.exporter.report.e2e.js
@@ -20,96 +20,7 @@ import {
 import { checkBodyText } from '../support/checks.js'
 
 describe('Accredited exporter report flow @accreditedExporter', () => {
-  it('should complete the full accredited exporter report flow through to confirmation @accreditedExporterFullFlow', async () => {
-    const regNumber = 'E25SR500020912PA'
-    const accNumber = 'E-ACC12245PA'
-
-    const organisationDetails = await createLinkedOrganisation([
-      {
-        material: 'Paper or board (R3)',
-        wasteProcessingType: 'Exporter'
-      }
-    ])
-
-    const migrationResponse = await updateMigratedOrganisation(
-      organisationDetails.refNo,
-      [
-        {
-          regNumber,
-          accNumber,
-          status: 'approved'
-        }
-      ]
-    )
-
-    const user = await createAndRegisterDefraIdUser(migrationResponse.email)
-    await linkDefraIdUser(
-      organisationDetails.refNo,
-      user.userId,
-      migrationResponse.email
-    )
-
-    await HomePage.openStart()
-    await HomePage.clickStartNow()
-    await DefraIdStubPage.loginViaEmail(migrationResponse.email)
-
-    // Upload summary log so report data exists
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.submitSummaryLogLink()
-
-    const filePath = `resources/sanity/exporter_${accNumber}_${regNumber}.xlsx`
-    await UploadSummaryLogPage.performUploadAndReturnToHomepage(filePath)
-
-    // Navigate to reports
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.manageReportsLink()
-
-    // Start the report — should redirect to prn-summary for accredited exporter
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
-
-    // --- PRN Summary page ---
-    const prnSummaryHeading = await PrnSummaryPage.headingText()
-    expect(prnSummaryHeading).toBeTruthy()
-
-    // Enter revenue
-    await PrnSummaryPage.enterRevenue('1500.50')
-    await PrnSummaryPage.continue()
-
-    // --- Free PERNs page ---
-    const freePernHeading = await FreePernPage.headingText()
-    expect(freePernHeading).toBeTruthy()
-
-    // Enter free PERN tonnage (must be <= issued tonnage)
-    await FreePernPage.enterTonnage('0')
-    await FreePernPage.continue()
-
-    // --- Supporting information page ---
-    const supportingInfoHeading =
-      await ReportSupportingInformationPage.headingText()
-    expect(supportingInfoHeading).toBe(
-      'Add supporting information for your regulator (optional)'
-    )
-    await ReportSupportingInformationPage.continue()
-
-    // --- Check your answers page ---
-    const checkHeading = await ReportCheckAnswersPage.headingText()
-    expect(checkHeading).toBe('Check your answers before creating draft report')
-
-    // Verify PRN revenue persists to CYA
-    await checkBodyText('1,500.50', 10)
-
-    // Submit the report
-    await ReportCheckAnswersPage.createReport()
-
-    // Verify confirmation page
-    await checkBodyText('report created', 30)
-
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
-  })
-
-  it('should save and come back later from PRN summary and free PERNs pages @accreditedExporterSave', async () => {
+  it('should navigate back correctly through the accredited exporter flow @accreditedExporterBackLinks', async () => {
     const regNumber = 'E25SR500020912PA'
     const accNumber = 'E-ACC12245PA'
 
@@ -155,32 +66,36 @@ describe('Accredited exporter report flow @accreditedExporter', () => {
     await ReportsPage.selectActionLink(1)
     await ReportDetailPage.useThisData()
 
-    // --- Save from PRN summary page ---
-    await PrnSummaryPage.enterRevenue('500')
-    await PrnSummaryPage.saveAndComeBackLater()
+    // On prn-summary — back link goes to detail page
+    await PrnSummaryPage.selectBackLink()
+    const detailHeading = await ReportDetailPage.headingText()
+    expect(detailHeading).toBeTruthy()
 
-    // Should redirect back to reports list
-    const reportsHeading = await ReportsPage.headingText()
-    expect(reportsHeading).toContain('Reports')
+    // Go forward again
+    await ReportDetailPage.useThisData()
 
-    // Resume the report — Continue goes directly to prn-summary for accredited exporters
-    await ReportsPage.selectActionLink(1)
-
-    // Continue past prn-summary to free-perns
-    await PrnSummaryPage.enterRevenue('500')
+    // Continue to free-perns
+    await PrnSummaryPage.enterRevenue('100')
     await PrnSummaryPage.continue()
 
-    // --- Save from free PERNs page ---
+    // On free-perns — back link goes to prn-summary
+    await FreePernPage.selectBackLink()
+    const backToPrnSummary = await PrnSummaryPage.headingText()
+    expect(backToPrnSummary).toBeTruthy()
+
+    // Continue through to supporting info
+    await PrnSummaryPage.enterRevenue('100')
+    await PrnSummaryPage.continue()
     await FreePernPage.enterTonnage('0')
-    await FreePernPage.saveAndComeBackLater()
+    await FreePernPage.continue()
 
-    // Should redirect back to reports list
-    const reportsHeadingAfterSave = await ReportsPage.headingText()
-    expect(reportsHeadingAfterSave).toContain('Reports')
+    // On supporting info — back link goes to free-perns
+    await ReportSupportingInformationPage.selectBackLink()
+    const backToFreePern = await FreePernPage.headingText()
+    expect(backToFreePern).toBeTruthy()
 
-    // Clean up — delete the report (Continue goes directly to prn-summary)
-    await ReportsPage.selectActionLink(1)
-    await PrnSummaryPage.deleteReportLink()
+    // Clean up
+    await FreePernPage.deleteReportLink()
     await ConfirmDeleteReportPage.confirmDeletion()
 
     await HomePage.signOut()
@@ -279,7 +194,7 @@ describe('Accredited exporter report flow @accreditedExporter', () => {
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
   })
 
-  it('should navigate back correctly through the accredited exporter flow @accreditedExporterBackLinks', async () => {
+  it('should save and come back later from PRN summary and free PERNs pages @accreditedExporterSave', async () => {
     const regNumber = 'E25SR500020912PA'
     const accNumber = 'E-ACC12245PA'
 
@@ -325,37 +240,122 @@ describe('Accredited exporter report flow @accreditedExporter', () => {
     await ReportsPage.selectActionLink(1)
     await ReportDetailPage.useThisData()
 
-    // On prn-summary — back link goes to detail page
-    await PrnSummaryPage.selectBackLink()
-    const detailHeading = await ReportDetailPage.headingText()
-    expect(detailHeading).toBeTruthy()
+    // --- Save from PRN summary page ---
+    await PrnSummaryPage.enterRevenue('500')
+    await PrnSummaryPage.saveAndComeBackLater()
 
-    // Go forward again
+    // Should redirect back to reports list
+    const reportsHeading = await ReportsPage.headingText()
+    expect(reportsHeading).toContain('Reports')
+
+    // Resume the report — Continue goes directly to prn-summary for accredited exporters
+    await ReportsPage.selectActionLink(1)
+
+    // Continue past prn-summary to free-perns
+    await PrnSummaryPage.enterRevenue('500')
+    await PrnSummaryPage.continue()
+
+    // --- Save from free PERNs page ---
+    await FreePernPage.enterTonnage('0')
+    await FreePernPage.saveAndComeBackLater()
+
+    // Should redirect back to reports list
+    const reportsHeadingAfterSave = await ReportsPage.headingText()
+    expect(reportsHeadingAfterSave).toContain('Reports')
+
+    // Clean up — delete the report (Continue goes directly to prn-summary)
+    await ReportsPage.selectActionLink(1)
+    await PrnSummaryPage.deleteReportLink()
+    await ConfirmDeleteReportPage.confirmDeletion()
+
+    await HomePage.signOut()
+    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+  })
+
+  it('should complete the full accredited exporter report flow through to confirmation @accreditedExporterFullFlow', async () => {
+    const regNumber = 'E25SR500020912PA'
+    const accNumber = 'E-ACC12245PA'
+
+    const organisationDetails = await createLinkedOrganisation([
+      {
+        material: 'Paper or board (R3)',
+        wasteProcessingType: 'Exporter'
+      }
+    ])
+
+    const migrationResponse = await updateMigratedOrganisation(
+      organisationDetails.refNo,
+      [
+        {
+          regNumber,
+          accNumber,
+          status: 'approved'
+        }
+      ]
+    )
+
+    const user = await createAndRegisterDefraIdUser(migrationResponse.email)
+    await linkDefraIdUser(
+      organisationDetails.refNo,
+      user.userId,
+      migrationResponse.email
+    )
+
+    await HomePage.openStart()
+    await HomePage.clickStartNow()
+    await DefraIdStubPage.loginViaEmail(migrationResponse.email)
+
+    // Upload summary log so report data exists
+    await DashboardPage.selectTableLink(1, 1)
+    await WasteRecordsPage.submitSummaryLogLink()
+
+    const filePath = `resources/sanity/exporter_${accNumber}_${regNumber}.xlsx`
+    await UploadSummaryLogPage.performUploadAndReturnToHomepage(filePath)
+
+    // Navigate to reports
+    await DashboardPage.selectTableLink(1, 1)
+    await WasteRecordsPage.manageReportsLink()
+
+    // Start the report — should redirect to prn-summary for accredited exporter
+    await ReportsPage.selectActionLink(1)
     await ReportDetailPage.useThisData()
 
-    // Continue to free-perns
-    await PrnSummaryPage.enterRevenue('100')
+    // --- PRN Summary page ---
+    const prnSummaryHeading = await PrnSummaryPage.headingText()
+    expect(prnSummaryHeading).toBeTruthy()
+
+    // Enter revenue
+    await PrnSummaryPage.enterRevenue('1500.50')
     await PrnSummaryPage.continue()
 
-    // On free-perns — back link goes to prn-summary
-    await FreePernPage.selectBackLink()
-    const backToPrnSummary = await PrnSummaryPage.headingText()
-    expect(backToPrnSummary).toBeTruthy()
+    // --- Free PERNs page ---
+    const freePernHeading = await FreePernPage.headingText()
+    expect(freePernHeading).toBeTruthy()
 
-    // Continue through to supporting info
-    await PrnSummaryPage.enterRevenue('100')
-    await PrnSummaryPage.continue()
+    // Enter free PERN tonnage (must be <= issued tonnage)
     await FreePernPage.enterTonnage('0')
     await FreePernPage.continue()
 
-    // On supporting info — back link goes to free-perns
-    await ReportSupportingInformationPage.selectBackLink()
-    const backToFreePern = await FreePernPage.headingText()
-    expect(backToFreePern).toBeTruthy()
+    // --- Supporting information page ---
+    const supportingInfoHeading =
+      await ReportSupportingInformationPage.headingText()
+    expect(supportingInfoHeading).toBe(
+      'Add supporting information for your regulator (optional)'
+    )
+    await ReportSupportingInformationPage.continue()
 
-    // Clean up
-    await FreePernPage.deleteReportLink()
-    await ConfirmDeleteReportPage.confirmDeletion()
+    // --- Check your answers page ---
+    const checkHeading = await ReportCheckAnswersPage.headingText()
+    expect(checkHeading).toBe('Check your answers before creating draft report')
+
+    // Verify PRN revenue persists to CYA
+    await checkBodyText('1,500.50', 10)
+
+    // Submit the report
+    await ReportCheckAnswersPage.createReport()
+
+    // Verify confirmation page
+    await checkBodyText('report created', 30)
 
     await HomePage.signOut()
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))

--- a/test/specs/accredited.reprocessor.report.e2e.js
+++ b/test/specs/accredited.reprocessor.report.e2e.js
@@ -70,289 +70,284 @@ async function uploadAndNavigateToReports() {
 }
 
 describe('Accredited reprocessor report flow @accreditedReprocessor', () => {
-  it('should navigate back correctly through the accredited reprocessor flow @accreditedReprocessorBackLinks', async () => {
-    await setupAccreditedReprocessor()
-    await uploadAndNavigateToReports()
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
+  describe('accredited reprocessor with upload', () => {
+    before(async () => {
+      await setupAccreditedReprocessor()
+      await uploadAndNavigateToReports()
+    })
 
-    // On tonnes-recycled — back link goes to detail page
-    await TonnesRecycledPage.selectBackLink()
-    const detailHeading = await ReportDetailPage.headingText()
-    expect(detailHeading).toBeTruthy()
+    after(async () => {
+      await HomePage.signOut()
+      await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+    })
 
-    // Go forward again
-    await ReportDetailPage.useThisData()
+    it('should navigate back correctly through the accredited reprocessor flow @accreditedReprocessorBackLinks', async () => {
+      await ReportsPage.selectActionLink(1)
+      await ReportDetailPage.useThisData()
 
-    // Continue to tonnes-not-recycled
-    await TonnesRecycledPage.enterTonnage('15.02')
-    await TonnesRecycledPage.continue()
+      // On tonnes-recycled — back link goes to detail page
+      await TonnesRecycledPage.selectBackLink()
+      const detailHeading = await ReportDetailPage.headingText()
+      expect(detailHeading).toBeTruthy()
 
-    // On tonnes-not-recycled — back link goes to tonnes-recycled
-    await TonnesNotRecycledPage.selectBackLink()
-    const backToTonnesRecycled = await TonnesRecycledPage.headingText()
-    expect(backToTonnesRecycled).toBeTruthy()
+      // Go forward again
+      await ReportDetailPage.useThisData()
 
-    // Continue through to prn-summary
-    await TonnesRecycledPage.enterTonnage('15.02')
-    await TonnesRecycledPage.continue()
-    await TonnesNotRecycledPage.enterTonnage('89.31')
-    await TonnesNotRecycledPage.continue()
+      // Continue to tonnes-not-recycled
+      await TonnesRecycledPage.enterTonnage('15.02')
+      await TonnesRecycledPage.continue()
 
-    // On prn-summary — back link goes to tonnes-not-recycled
-    await ReprocessorPrnSummaryPage.selectBackLink()
-    const backToTonnesNotRecycled = await TonnesNotRecycledPage.headingText()
-    expect(backToTonnesNotRecycled).toBeTruthy()
+      // On tonnes-not-recycled — back link goes to tonnes-recycled
+      await TonnesNotRecycledPage.selectBackLink()
+      const backToTonnesRecycled = await TonnesRecycledPage.headingText()
+      expect(backToTonnesRecycled).toBeTruthy()
 
-    // Continue through to free-prns
-    await TonnesNotRecycledPage.enterTonnage('89.31')
-    await TonnesNotRecycledPage.continue()
-    await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
-    await ReprocessorPrnSummaryPage.continue()
+      // Continue through to prn-summary
+      await TonnesRecycledPage.enterTonnage('15.02')
+      await TonnesRecycledPage.continue()
+      await TonnesNotRecycledPage.enterTonnage('89.31')
+      await TonnesNotRecycledPage.continue()
 
-    // On free-prns — back link goes to prn-summary
-    await FreePrnsPage.selectBackLink()
-    const backToPrnSummary = await ReprocessorPrnSummaryPage.headingText()
-    expect(backToPrnSummary).toBeTruthy()
+      // On prn-summary — back link goes to tonnes-not-recycled
+      await ReprocessorPrnSummaryPage.selectBackLink()
+      const backToTonnesNotRecycled = await TonnesNotRecycledPage.headingText()
+      expect(backToTonnesNotRecycled).toBeTruthy()
 
-    // Continue through to supporting info
-    await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
-    await ReprocessorPrnSummaryPage.continue()
-    await FreePrnsPage.enterTonnage('0')
-    await FreePrnsPage.continue()
+      // Continue through to free-prns
+      await TonnesNotRecycledPage.enterTonnage('89.31')
+      await TonnesNotRecycledPage.continue()
+      await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
+      await ReprocessorPrnSummaryPage.continue()
 
-    // On supporting info — back link goes to free-prns
-    await ReportSupportingInformationPage.selectBackLink()
-    const backToFreePrns = await FreePrnsPage.headingText()
-    expect(backToFreePrns).toBeTruthy()
+      // On free-prns — back link goes to prn-summary
+      await FreePrnsPage.selectBackLink()
+      const backToPrnSummary = await ReprocessorPrnSummaryPage.headingText()
+      expect(backToPrnSummary).toBeTruthy()
 
-    // Clean up
-    await FreePrnsPage.deleteReportLink()
-    await ConfirmDeleteReportPage.confirmDeletion()
+      // Continue through to supporting info
+      await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
+      await ReprocessorPrnSummaryPage.continue()
+      await FreePrnsPage.enterTonnage('0')
+      await FreePrnsPage.continue()
 
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+      // On supporting info — back link goes to free-prns
+      await ReportSupportingInformationPage.selectBackLink()
+      const backToFreePrns = await FreePrnsPage.headingText()
+      expect(backToFreePrns).toBeTruthy()
+
+      // Clean up — delete report so next test starts fresh
+      await FreePrnsPage.deleteReportLink()
+      await ConfirmDeleteReportPage.confirmDeletion()
+    })
+
+    it('should navigate to delete confirmation from tonnes recycled and PRN summary pages @accreditedReprocessorDelete', async () => {
+      await ReportsPage.selectActionLink(1)
+      await ReportDetailPage.useThisData()
+
+      // --- Delete from tonnes recycled page ---
+      await TonnesRecycledPage.deleteReportLink()
+
+      const deleteHeading = await ConfirmDeleteReportPage.headingText()
+      expect(deleteHeading).toBe('Confirm deletion of this report')
+
+      // Back link should return to tonnes-recycled
+      await ConfirmDeleteReportPage.selectBackLink()
+      const backToTonnesRecycled = await TonnesRecycledPage.headingText()
+      expect(backToTonnesRecycled).toBeTruthy()
+
+      // Confirm deletion
+      await TonnesRecycledPage.deleteReportLink()
+      await ConfirmDeleteReportPage.confirmDeletion()
+
+      // Should be back on reports list with status reverted to Due
+      let reportsHeading = await ReportsPage.headingText()
+      expect(reportsHeading).toContain('Reports')
+
+      let statusBadge = await ReportsPage.getStatusBadge(1)
+      expect(statusBadge).toBe('Due')
+
+      // --- Create report again, navigate to prn-summary, delete from there ---
+      await ReportsPage.selectActionLink(1)
+      await ReportDetailPage.useThisData()
+      await TonnesRecycledPage.enterTonnage('15.02')
+      await TonnesRecycledPage.continue()
+      await TonnesNotRecycledPage.enterTonnage('89.31')
+      await TonnesNotRecycledPage.continue()
+
+      await ReprocessorPrnSummaryPage.deleteReportLink()
+
+      const deleteHeading2 = await ConfirmDeleteReportPage.headingText()
+      expect(deleteHeading2).toBe('Confirm deletion of this report')
+
+      await ConfirmDeleteReportPage.confirmDeletion()
+
+      // Should be back on reports list with status reverted to Due
+      reportsHeading = await ReportsPage.headingText()
+      expect(reportsHeading).toContain('Reports')
+
+      statusBadge = await ReportsPage.getStatusBadge(1)
+      expect(statusBadge).toBe('Due')
+    })
+
+    it('should save and come back later from tonnes recycled page @accreditedReprocessorSave', async () => {
+      await ReportsPage.selectActionLink(1)
+      await ReportDetailPage.useThisData()
+
+      // --- Save from tonnes recycled page ---
+      await TonnesRecycledPage.enterTonnage('15.02')
+      await TonnesRecycledPage.saveAndComeBackLater()
+
+      // Should redirect back to reports list
+      const reportsHeading = await ReportsPage.headingText()
+      expect(reportsHeading).toContain('Reports')
+
+      // Resume the report — should land on tonnes-recycled with pre-populated data
+      await ReportsPage.selectActionLink(1)
+
+      // Verify we're back on tonnes-recycled with pre-populated data
+      const tonnesRecycledHeading = await TonnesRecycledPage.headingText()
+      expect(tonnesRecycledHeading).toBeTruthy()
+
+      const prePopulatedValue = await TonnesRecycledPage.getValue()
+      expect(prePopulatedValue).toBe('15.02')
+
+      // Complete the remaining flow
+      await TonnesRecycledPage.enterTonnage('15.02')
+      await TonnesRecycledPage.continue()
+
+      await TonnesNotRecycledPage.enterTonnage('89.31')
+      await TonnesNotRecycledPage.continue()
+
+      await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
+      await ReprocessorPrnSummaryPage.continue()
+
+      await FreePrnsPage.enterTonnage('0')
+      await FreePrnsPage.continue()
+
+      await ReportSupportingInformationPage.continue()
+
+      // Verify CYA page
+      const checkHeading = await ReportCheckAnswersPage.headingText()
+      expect(checkHeading).toBe(
+        'Check your answers before creating draft report'
+      )
+
+      // Clean up — delete the report
+      await ReportCheckAnswersPage.deleteAndStartAgainLink()
+      await ConfirmDeleteReportPage.confirmDeletion()
+    })
+
+    it('should complete the full accredited reprocessor report flow through to confirmation @accreditedReprocessorFullFlow', async () => {
+      await ReportsPage.selectActionLink(1)
+      await ReportDetailPage.useThisData()
+
+      // --- Tonnes recycled page ---
+      const tonnesRecycledHeading = await TonnesRecycledPage.headingText()
+      expect(tonnesRecycledHeading).toBeTruthy()
+
+      await TonnesRecycledPage.enterTonnage('15.02')
+      await TonnesRecycledPage.continue()
+
+      // --- Tonnes not recycled page ---
+      const tonnesNotRecycledHeading = await TonnesNotRecycledPage.headingText()
+      expect(tonnesNotRecycledHeading).toBeTruthy()
+
+      await TonnesNotRecycledPage.enterTonnage('89.31')
+      await TonnesNotRecycledPage.continue()
+
+      // --- PRN summary page ---
+      const prnSummaryHeading = await ReprocessorPrnSummaryPage.headingText()
+      expect(prnSummaryHeading).toBeTruthy()
+
+      await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
+      await ReprocessorPrnSummaryPage.continue()
+
+      // --- Free PRNs page ---
+      const freePrnsHeading = await FreePrnsPage.headingText()
+      expect(freePrnsHeading).toBeTruthy()
+
+      await FreePrnsPage.enterTonnage('0')
+      await FreePrnsPage.continue()
+
+      // --- Supporting information page ---
+      const supportingInfoHeading =
+        await ReportSupportingInformationPage.headingText()
+      expect(supportingInfoHeading).toBe(
+        'Add supporting information for your regulator (optional)'
+      )
+      await ReportSupportingInformationPage.continue()
+
+      // --- Check your answers page ---
+      const checkHeading = await ReportCheckAnswersPage.headingText()
+      expect(checkHeading).toBe(
+        'Check your answers before creating draft report'
+      )
+
+      // Verify data persists to CYA
+      await checkBodyText('15.02', 10)
+      await checkBodyText('89.31', 10)
+      await checkBodyText('1,576.12', 10)
+
+      // Verify average price per tonne is calculated and displayed
+      await checkBodyText('Average price per tonne', 10)
+
+      // Submit the report
+      await ReportCheckAnswersPage.createReport()
+
+      // Verify confirmation page
+      await checkBodyText('report created', 30)
+    })
   })
 
-  it('should navigate to delete confirmation from tonnes recycled and PRN summary pages @accreditedReprocessorDelete', async () => {
-    await setupAccreditedReprocessor()
-    await uploadAndNavigateToReports()
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
-
-    // --- Delete from tonnes recycled page ---
-    await TonnesRecycledPage.deleteReportLink()
-
-    const deleteHeading = await ConfirmDeleteReportPage.headingText()
-    expect(deleteHeading).toBe('Confirm deletion of this report')
-
-    // Back link should return to tonnes-recycled
-    await ConfirmDeleteReportPage.selectBackLink()
-    const backToTonnesRecycled = await TonnesRecycledPage.headingText()
-    expect(backToTonnesRecycled).toBeTruthy()
-
-    // Confirm deletion
-    await TonnesRecycledPage.deleteReportLink()
-    await ConfirmDeleteReportPage.confirmDeletion()
-
-    // Should be back on reports list with status reverted to Due
-    let reportsHeading = await ReportsPage.headingText()
-    expect(reportsHeading).toContain('Reports')
-
-    let statusBadge = await ReportsPage.getStatusBadge(1)
-    expect(statusBadge).toBe('Due')
-
-    // --- Create report again, navigate to prn-summary, delete from there ---
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
-    await TonnesRecycledPage.enterTonnage('15.02')
-    await TonnesRecycledPage.continue()
-    await TonnesNotRecycledPage.enterTonnage('89.31')
-    await TonnesNotRecycledPage.continue()
-
-    await ReprocessorPrnSummaryPage.deleteReportLink()
-
-    const deleteHeading2 = await ConfirmDeleteReportPage.headingText()
-    expect(deleteHeading2).toBe('Confirm deletion of this report')
-
-    await ConfirmDeleteReportPage.confirmDeletion()
-
-    // Should be back on reports list with status reverted to Due
-    reportsHeading = await ReportsPage.headingText()
-    expect(reportsHeading).toContain('Reports')
-
-    statusBadge = await ReportsPage.getStatusBadge(1)
-    expect(statusBadge).toBe('Due')
-
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
-  })
-
-  it('should save and come back later from tonnes recycled page @accreditedReprocessorSave', async () => {
-    await setupAccreditedReprocessor()
-    await uploadAndNavigateToReports()
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
-
-    // --- Save from tonnes recycled page ---
-    await TonnesRecycledPage.enterTonnage('15.02')
-    await TonnesRecycledPage.saveAndComeBackLater()
-
-    // Should redirect back to reports list
-    const reportsHeading = await ReportsPage.headingText()
-    expect(reportsHeading).toContain('Reports')
-
-    // Resume the report — should land on tonnes-recycled with pre-populated data
-    await ReportsPage.selectActionLink(1)
-
-    // Verify we're back on tonnes-recycled with pre-populated data
-    const tonnesRecycledHeading = await TonnesRecycledPage.headingText()
-    expect(tonnesRecycledHeading).toBeTruthy()
-
-    const prePopulatedValue = await TonnesRecycledPage.getValue()
-    expect(prePopulatedValue).toBe('15.02')
-
-    // Complete the remaining flow
-    await TonnesRecycledPage.enterTonnage('15.02')
-    await TonnesRecycledPage.continue()
-
-    await TonnesNotRecycledPage.enterTonnage('89.31')
-    await TonnesNotRecycledPage.continue()
-
-    await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
-    await ReprocessorPrnSummaryPage.continue()
-
-    await FreePrnsPage.enterTonnage('0')
-    await FreePrnsPage.continue()
-
-    await ReportSupportingInformationPage.continue()
-
-    // Verify CYA page
-    const checkHeading = await ReportCheckAnswersPage.headingText()
-    expect(checkHeading).toBe('Check your answers before creating draft report')
-
-    // Clean up — delete the report
-    await ReportCheckAnswersPage.deleteAndStartAgainLink()
-    await ConfirmDeleteReportPage.confirmDeletion()
-
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
-  })
-
-  it('should complete the full accredited reprocessor report flow through to confirmation @accreditedReprocessorFullFlow', async () => {
-    await setupAccreditedReprocessor()
-
-    await uploadAndNavigateToReports()
-
-    // Start the report — should redirect to tonnes-recycled for accredited reprocessor
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
-
-    // --- Tonnes recycled page ---
-    const tonnesRecycledHeading = await TonnesRecycledPage.headingText()
-    expect(tonnesRecycledHeading).toBeTruthy()
-
-    await TonnesRecycledPage.enterTonnage('15.02')
-    await TonnesRecycledPage.continue()
-
-    // --- Tonnes not recycled page ---
-    const tonnesNotRecycledHeading = await TonnesNotRecycledPage.headingText()
-    expect(tonnesNotRecycledHeading).toBeTruthy()
-
-    await TonnesNotRecycledPage.enterTonnage('89.31')
-    await TonnesNotRecycledPage.continue()
-
-    // --- PRN summary page ---
-    const prnSummaryHeading = await ReprocessorPrnSummaryPage.headingText()
-    expect(prnSummaryHeading).toBeTruthy()
-
-    await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
-    await ReprocessorPrnSummaryPage.continue()
-
-    // --- Free PRNs page ---
-    const freePrnsHeading = await FreePrnsPage.headingText()
-    expect(freePrnsHeading).toBeTruthy()
-
-    await FreePrnsPage.enterTonnage('0')
-    await FreePrnsPage.continue()
-
-    // --- Supporting information page ---
-    const supportingInfoHeading =
-      await ReportSupportingInformationPage.headingText()
-    expect(supportingInfoHeading).toBe(
-      'Add supporting information for your regulator (optional)'
-    )
-    await ReportSupportingInformationPage.continue()
-
-    // --- Check your answers page ---
-    const checkHeading = await ReportCheckAnswersPage.headingText()
-    expect(checkHeading).toBe('Check your answers before creating draft report')
-
-    // Verify data persists to CYA
-    await checkBodyText('15.02', 10)
-    await checkBodyText('89.31', 10)
-    await checkBodyText('1,576.12', 10)
-
-    // Verify average price per tonne is calculated and displayed
-    await checkBodyText('Average price per tonne', 10)
-
-    // Submit the report
-    await ReportCheckAnswersPage.createReport()
-
-    // Verify confirmation page
-    await checkBodyText('report created', 30)
-
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
-  })
-
-  it('should return 404 when registered-only reprocessor tries to access PRN pages @registeredOnlyReprocessorRouteGuard', async () => {
-    const organisationDetails = await createLinkedOrganisation([
-      {
-        material: 'Paper or board (R3)',
-        wasteProcessingType: 'Reprocessor',
-        withoutAccreditation: true
-      }
-    ])
-
-    const migrationResponse = await updateMigratedOrganisation(
-      organisationDetails.refNo,
-      [
+  describe('non-accredited reprocessor route guard', () => {
+    it('should return 404 when registered-only reprocessor tries to access PRN pages @registeredOnlyReprocessorRouteGuard', async () => {
+      const organisationDetails = await createLinkedOrganisation([
         {
-          reprocessingType: 'output',
-          regNumber: 'R25SR500030913PA',
-          status: 'approved',
+          material: 'Paper or board (R3)',
+          wasteProcessingType: 'Reprocessor',
           withoutAccreditation: true
         }
-      ]
-    )
+      ])
 
-    const user = await createAndRegisterDefraIdUser(migrationResponse.email)
-    await linkDefraIdUser(
-      organisationDetails.refNo,
-      user.userId,
-      migrationResponse.email
-    )
+      const migrationResponse = await updateMigratedOrganisation(
+        organisationDetails.refNo,
+        [
+          {
+            reprocessingType: 'output',
+            regNumber: 'R25SR500030913PA',
+            status: 'approved',
+            withoutAccreditation: true
+          }
+        ]
+      )
 
-    await HomePage.openStart()
-    await HomePage.clickStartNow()
-    await DefraIdStubPage.loginViaEmail(migrationResponse.email)
+      const user = await createAndRegisterDefraIdUser(migrationResponse.email)
+      await linkDefraIdUser(
+        organisationDetails.refNo,
+        user.userId,
+        migrationResponse.email
+      )
 
-    // Try to access prn-summary directly — should get 404
-    await browser.url(
-      `/organisations/${organisationDetails.refNo}/registrations/${migrationResponse.registrationIds[0]}/reports/2026/monthly/1/prn-summary`
-    )
-    await checkBodyText('404', 10)
-    await checkBodyText('Page not found', 10)
+      await HomePage.openStart()
+      await HomePage.clickStartNow()
+      await DefraIdStubPage.loginViaEmail(migrationResponse.email)
 
-    // Try to access free-prns directly — should get 404
-    await browser.url(
-      `/organisations/${organisationDetails.refNo}/registrations/${migrationResponse.registrationIds[0]}/reports/2026/monthly/1/free-prns`
-    )
-    await checkBodyText('404', 10)
-    await checkBodyText('Page not found', 10)
+      // Try to access prn-summary directly — should get 404
+      await browser.url(
+        `/organisations/${organisationDetails.refNo}/registrations/${migrationResponse.registrationIds[0]}/reports/2026/monthly/1/prn-summary`
+      )
+      await checkBodyText('404', 10)
+      await checkBodyText('Page not found', 10)
 
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+      // Try to access free-prns directly — should get 404
+      await browser.url(
+        `/organisations/${organisationDetails.refNo}/registrations/${migrationResponse.registrationIds[0]}/reports/2026/monthly/1/free-prns`
+      )
+      await checkBodyText('404', 10)
+      await checkBodyText('Page not found', 10)
+
+      await HomePage.signOut()
+      await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+    })
   })
 })

--- a/test/specs/accredited.reprocessor.report.e2e.js
+++ b/test/specs/accredited.reprocessor.report.e2e.js
@@ -70,6 +70,175 @@ async function uploadAndNavigateToReports() {
 }
 
 describe('Accredited reprocessor report flow @accreditedReprocessor', () => {
+  it('should navigate back correctly through the accredited reprocessor flow @accreditedReprocessorBackLinks', async () => {
+    await setupAccreditedReprocessor()
+    await uploadAndNavigateToReports()
+    await ReportsPage.selectActionLink(1)
+    await ReportDetailPage.useThisData()
+
+    // On tonnes-recycled — back link goes to detail page
+    await TonnesRecycledPage.selectBackLink()
+    const detailHeading = await ReportDetailPage.headingText()
+    expect(detailHeading).toBeTruthy()
+
+    // Go forward again
+    await ReportDetailPage.useThisData()
+
+    // Continue to tonnes-not-recycled
+    await TonnesRecycledPage.enterTonnage('15.02')
+    await TonnesRecycledPage.continue()
+
+    // On tonnes-not-recycled — back link goes to tonnes-recycled
+    await TonnesNotRecycledPage.selectBackLink()
+    const backToTonnesRecycled = await TonnesRecycledPage.headingText()
+    expect(backToTonnesRecycled).toBeTruthy()
+
+    // Continue through to prn-summary
+    await TonnesRecycledPage.enterTonnage('15.02')
+    await TonnesRecycledPage.continue()
+    await TonnesNotRecycledPage.enterTonnage('89.31')
+    await TonnesNotRecycledPage.continue()
+
+    // On prn-summary — back link goes to tonnes-not-recycled
+    await ReprocessorPrnSummaryPage.selectBackLink()
+    const backToTonnesNotRecycled = await TonnesNotRecycledPage.headingText()
+    expect(backToTonnesNotRecycled).toBeTruthy()
+
+    // Continue through to free-prns
+    await TonnesNotRecycledPage.enterTonnage('89.31')
+    await TonnesNotRecycledPage.continue()
+    await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
+    await ReprocessorPrnSummaryPage.continue()
+
+    // On free-prns — back link goes to prn-summary
+    await FreePrnsPage.selectBackLink()
+    const backToPrnSummary = await ReprocessorPrnSummaryPage.headingText()
+    expect(backToPrnSummary).toBeTruthy()
+
+    // Continue through to supporting info
+    await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
+    await ReprocessorPrnSummaryPage.continue()
+    await FreePrnsPage.enterTonnage('0')
+    await FreePrnsPage.continue()
+
+    // On supporting info — back link goes to free-prns
+    await ReportSupportingInformationPage.selectBackLink()
+    const backToFreePrns = await FreePrnsPage.headingText()
+    expect(backToFreePrns).toBeTruthy()
+
+    // Clean up
+    await FreePrnsPage.deleteReportLink()
+    await ConfirmDeleteReportPage.confirmDeletion()
+
+    await HomePage.signOut()
+    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+  })
+
+  it('should navigate to delete confirmation from tonnes recycled and PRN summary pages @accreditedReprocessorDelete', async () => {
+    await setupAccreditedReprocessor()
+    await uploadAndNavigateToReports()
+    await ReportsPage.selectActionLink(1)
+    await ReportDetailPage.useThisData()
+
+    // --- Delete from tonnes recycled page ---
+    await TonnesRecycledPage.deleteReportLink()
+
+    const deleteHeading = await ConfirmDeleteReportPage.headingText()
+    expect(deleteHeading).toBe('Confirm deletion of this report')
+
+    // Back link should return to tonnes-recycled
+    await ConfirmDeleteReportPage.selectBackLink()
+    const backToTonnesRecycled = await TonnesRecycledPage.headingText()
+    expect(backToTonnesRecycled).toBeTruthy()
+
+    // Confirm deletion
+    await TonnesRecycledPage.deleteReportLink()
+    await ConfirmDeleteReportPage.confirmDeletion()
+
+    // Should be back on reports list with status reverted to Due
+    let reportsHeading = await ReportsPage.headingText()
+    expect(reportsHeading).toContain('Reports')
+
+    let statusBadge = await ReportsPage.getStatusBadge(1)
+    expect(statusBadge).toBe('Due')
+
+    // --- Create report again, navigate to prn-summary, delete from there ---
+    await ReportsPage.selectActionLink(1)
+    await ReportDetailPage.useThisData()
+    await TonnesRecycledPage.enterTonnage('15.02')
+    await TonnesRecycledPage.continue()
+    await TonnesNotRecycledPage.enterTonnage('89.31')
+    await TonnesNotRecycledPage.continue()
+
+    await ReprocessorPrnSummaryPage.deleteReportLink()
+
+    const deleteHeading2 = await ConfirmDeleteReportPage.headingText()
+    expect(deleteHeading2).toBe('Confirm deletion of this report')
+
+    await ConfirmDeleteReportPage.confirmDeletion()
+
+    // Should be back on reports list with status reverted to Due
+    reportsHeading = await ReportsPage.headingText()
+    expect(reportsHeading).toContain('Reports')
+
+    statusBadge = await ReportsPage.getStatusBadge(1)
+    expect(statusBadge).toBe('Due')
+
+    await HomePage.signOut()
+    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+  })
+
+  it('should save and come back later from tonnes recycled page @accreditedReprocessorSave', async () => {
+    await setupAccreditedReprocessor()
+    await uploadAndNavigateToReports()
+    await ReportsPage.selectActionLink(1)
+    await ReportDetailPage.useThisData()
+
+    // --- Save from tonnes recycled page ---
+    await TonnesRecycledPage.enterTonnage('15.02')
+    await TonnesRecycledPage.saveAndComeBackLater()
+
+    // Should redirect back to reports list
+    const reportsHeading = await ReportsPage.headingText()
+    expect(reportsHeading).toContain('Reports')
+
+    // Resume the report — should land on tonnes-recycled with pre-populated data
+    await ReportsPage.selectActionLink(1)
+
+    // Verify we're back on tonnes-recycled with pre-populated data
+    const tonnesRecycledHeading = await TonnesRecycledPage.headingText()
+    expect(tonnesRecycledHeading).toBeTruthy()
+
+    const prePopulatedValue = await TonnesRecycledPage.getValue()
+    expect(prePopulatedValue).toBe('15.02')
+
+    // Complete the remaining flow
+    await TonnesRecycledPage.enterTonnage('15.02')
+    await TonnesRecycledPage.continue()
+
+    await TonnesNotRecycledPage.enterTonnage('89.31')
+    await TonnesNotRecycledPage.continue()
+
+    await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
+    await ReprocessorPrnSummaryPage.continue()
+
+    await FreePrnsPage.enterTonnage('0')
+    await FreePrnsPage.continue()
+
+    await ReportSupportingInformationPage.continue()
+
+    // Verify CYA page
+    const checkHeading = await ReportCheckAnswersPage.headingText()
+    expect(checkHeading).toBe('Check your answers before creating draft report')
+
+    // Clean up — delete the report
+    await ReportCheckAnswersPage.deleteAndStartAgainLink()
+    await ConfirmDeleteReportPage.confirmDeletion()
+
+    await HomePage.signOut()
+    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+  })
+
   it('should complete the full accredited reprocessor report flow through to confirmation @accreditedReprocessorFullFlow', async () => {
     await setupAccreditedReprocessor()
 
@@ -132,175 +301,6 @@ describe('Accredited reprocessor report flow @accreditedReprocessor', () => {
 
     // Verify confirmation page
     await checkBodyText('report created', 30)
-
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
-  })
-
-  it('should save and come back later from tonnes recycled page @accreditedReprocessorSave', async () => {
-    await setupAccreditedReprocessor()
-    await uploadAndNavigateToReports()
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
-
-    // --- Save from tonnes recycled page ---
-    await TonnesRecycledPage.enterTonnage('15.02')
-    await TonnesRecycledPage.saveAndComeBackLater()
-
-    // Should redirect back to reports list
-    const reportsHeading = await ReportsPage.headingText()
-    expect(reportsHeading).toContain('Reports')
-
-    // Resume the report — should land on tonnes-recycled with pre-populated data
-    await ReportsPage.selectActionLink(1)
-
-    // Verify we're back on tonnes-recycled with pre-populated data
-    const tonnesRecycledHeading = await TonnesRecycledPage.headingText()
-    expect(tonnesRecycledHeading).toBeTruthy()
-
-    const prePopulatedValue = await TonnesRecycledPage.getValue()
-    expect(prePopulatedValue).toBe('15.02')
-
-    // Complete the remaining flow
-    await TonnesRecycledPage.enterTonnage('15.02')
-    await TonnesRecycledPage.continue()
-
-    await TonnesNotRecycledPage.enterTonnage('89.31')
-    await TonnesNotRecycledPage.continue()
-
-    await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
-    await ReprocessorPrnSummaryPage.continue()
-
-    await FreePrnsPage.enterTonnage('0')
-    await FreePrnsPage.continue()
-
-    await ReportSupportingInformationPage.continue()
-
-    // Verify CYA page
-    const checkHeading = await ReportCheckAnswersPage.headingText()
-    expect(checkHeading).toBe('Check your answers before creating draft report')
-
-    // Clean up — delete the report
-    await ReportCheckAnswersPage.deleteAndStartAgainLink()
-    await ConfirmDeleteReportPage.confirmDeletion()
-
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
-  })
-
-  it('should navigate to delete confirmation from tonnes recycled and PRN summary pages @accreditedReprocessorDelete', async () => {
-    await setupAccreditedReprocessor()
-    await uploadAndNavigateToReports()
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
-
-    // --- Delete from tonnes recycled page ---
-    await TonnesRecycledPage.deleteReportLink()
-
-    const deleteHeading = await ConfirmDeleteReportPage.headingText()
-    expect(deleteHeading).toBe('Confirm deletion of this report')
-
-    // Back link should return to tonnes-recycled
-    await ConfirmDeleteReportPage.selectBackLink()
-    const backToTonnesRecycled = await TonnesRecycledPage.headingText()
-    expect(backToTonnesRecycled).toBeTruthy()
-
-    // Confirm deletion
-    await TonnesRecycledPage.deleteReportLink()
-    await ConfirmDeleteReportPage.confirmDeletion()
-
-    // Should be back on reports list with status reverted to Due
-    let reportsHeading = await ReportsPage.headingText()
-    expect(reportsHeading).toContain('Reports')
-
-    let statusBadge = await ReportsPage.getStatusBadge(1)
-    expect(statusBadge).toBe('Due')
-
-    // --- Create report again, navigate to prn-summary, delete from there ---
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
-    await TonnesRecycledPage.enterTonnage('15.02')
-    await TonnesRecycledPage.continue()
-    await TonnesNotRecycledPage.enterTonnage('89.31')
-    await TonnesNotRecycledPage.continue()
-
-    await ReprocessorPrnSummaryPage.deleteReportLink()
-
-    const deleteHeading2 = await ConfirmDeleteReportPage.headingText()
-    expect(deleteHeading2).toBe('Confirm deletion of this report')
-
-    await ConfirmDeleteReportPage.confirmDeletion()
-
-    // Should be back on reports list with status reverted to Due
-    reportsHeading = await ReportsPage.headingText()
-    expect(reportsHeading).toContain('Reports')
-
-    statusBadge = await ReportsPage.getStatusBadge(1)
-    expect(statusBadge).toBe('Due')
-
-    await HomePage.signOut()
-    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
-  })
-
-  it('should navigate back correctly through the accredited reprocessor flow @accreditedReprocessorBackLinks', async () => {
-    await setupAccreditedReprocessor()
-    await uploadAndNavigateToReports()
-    await ReportsPage.selectActionLink(1)
-    await ReportDetailPage.useThisData()
-
-    // On tonnes-recycled — back link goes to detail page
-    await TonnesRecycledPage.selectBackLink()
-    const detailHeading = await ReportDetailPage.headingText()
-    expect(detailHeading).toBeTruthy()
-
-    // Go forward again
-    await ReportDetailPage.useThisData()
-
-    // Continue to tonnes-not-recycled
-    await TonnesRecycledPage.enterTonnage('15.02')
-    await TonnesRecycledPage.continue()
-
-    // On tonnes-not-recycled — back link goes to tonnes-recycled
-    await TonnesNotRecycledPage.selectBackLink()
-    const backToTonnesRecycled = await TonnesRecycledPage.headingText()
-    expect(backToTonnesRecycled).toBeTruthy()
-
-    // Continue through to prn-summary
-    await TonnesRecycledPage.enterTonnage('15.02')
-    await TonnesRecycledPage.continue()
-    await TonnesNotRecycledPage.enterTonnage('89.31')
-    await TonnesNotRecycledPage.continue()
-
-    // On prn-summary — back link goes to tonnes-not-recycled
-    await ReprocessorPrnSummaryPage.selectBackLink()
-    const backToTonnesNotRecycled = await TonnesNotRecycledPage.headingText()
-    expect(backToTonnesNotRecycled).toBeTruthy()
-
-    // Continue through to free-prns
-    await TonnesNotRecycledPage.enterTonnage('89.31')
-    await TonnesNotRecycledPage.continue()
-    await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
-    await ReprocessorPrnSummaryPage.continue()
-
-    // On free-prns — back link goes to prn-summary
-    await FreePrnsPage.selectBackLink()
-    const backToPrnSummary = await ReprocessorPrnSummaryPage.headingText()
-    expect(backToPrnSummary).toBeTruthy()
-
-    // Continue through to supporting info
-    await ReprocessorPrnSummaryPage.enterRevenue('1576.12')
-    await ReprocessorPrnSummaryPage.continue()
-    await FreePrnsPage.enterTonnage('0')
-    await FreePrnsPage.continue()
-
-    // On supporting info — back link goes to free-prns
-    await ReportSupportingInformationPage.selectBackLink()
-    const backToFreePrns = await FreePrnsPage.headingText()
-    expect(backToFreePrns).toBeTruthy()
-
-    // Clean up
-    await FreePrnsPage.deleteReportLink()
-    await ConfirmDeleteReportPage.confirmDeletion()
 
     await HomePage.signOut()
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -67,7 +67,7 @@ export const config = {
   },
 
   // Number of failures before the test suite bails.
-  bail: 0,
+  bail: 1,
   waitforTimeout: 10000,
   waitforInterval: 200,
   connectionRetryTimeout: 6000,


### PR DESCRIPTION
Ticket: [PAE-1303](https://eaflood.atlassian.net/browse/PAE-1303)
## Summary

- Extract shared org/user/upload setup into `before()` hooks in both accredited report spec files
- Each spec now does **1 upload instead of 4**, eliminating ~6 redundant file uploads + async processing waits
- Reorder tests: reversible operations (back links, delete, save) before irreversible submit (FullFlow)
- Route guard tests share a single non-accredited org via a separate `before()` hook

## Expected improvement

| Spec | Uploads before | Uploads after |
|------|---------------|---------------|
| Exporter (6 tests) | 4 | 1 |
| Reprocessor (5 tests) | 4 | 1 |

## Actual improvement

Before:
<img width="678" height="291" alt="Screenshot 2026-04-10 at 14 56 45" src="https://github.com/user-attachments/assets/7ee3a14c-4cab-4c2b-866a-02833970a2f6" />

After:
<img width="691" height="222" alt="Screenshot 2026-04-10 at 14 55 42" src="https://github.com/user-attachments/assets/141e3e89-79c1-4cfe-a7e6-abca63351357" />

## Test plan

- [ ] CI passes — all 11 tests across both specs still pass
- [ ] Compare CI timing with baseline (~3m40s per spec → target ~2m)

[PAE-1303]: https://eaflood.atlassian.net/browse/PAE-1303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ