### PR TITLE
PAE-000: Fix axios and basic-ftp vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2894,14 +2894,23 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/b4a": {
@@ -3022,9 +3031,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "undici": "7.24.5"
   },
   "overrides": {
+    "axios": "^1.15.0",
+    "basic-ftp": "5.2.2",
     "serialize-javascript": "^7.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
## Summary

Adds overrides for two transitive dependencies with known security vulnerabilities:

- **axios** 1.13.5 → 1.15.0 — fixes SSRF via NO_PROXY hostname normalisation bypass ([GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5), critical) and cloud metadata exfiltration via header injection ([GHSA-fvcv-3m26-pcqx](https://github.com/advisories/GHSA-fvcv-3m26-pcqx), critical). Pulled in via `@wdio/browserstack-service > @browserstack/ai-sdk-node`; the parent hasn't updated yet, so an override is used.
- **basic-ftp** 5.2.0 → 5.2.2 — fixes CRLF injection allowing arbitrary FTP command execution ([GHSA-chqc-8p9q-pq6q](https://github.com/advisories/GHSA-chqc-8p9q-pq6q), high) and incomplete CRLF injection protection ([GHSA-6v7q-wjvx-w8wg](https://github.com/advisories/GHSA-6v7q-wjvx-w8wg), high). Pulled in via `@wdio/cli > @puppeteer/browsers > proxy-agent > pac-proxy-agent > get-uri`; overridden because the parent chain hasn't updated.

### Overrides retained

- **`serialize-javascript`** (^7.0.5) — still needed; removing it reintroduces a high-severity vulnerability via mocha

npm audit reports zero vulnerabilities after these changes. Snyk reports only the `inflight` resource leak (medium, no patch available, abandoned package).