### PR TITLE
PAE-1330: Remove obsolete feature flags from compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -191,8 +191,6 @@ services:
       ENTRA_OIDC_WELL_KNOWN_CONFIGURATION_URL: http://epr-re-ex-entra-stub:3010/.well-known/openid-configuration
       FEATURE_FLAG_DEV_ENDPOINTS: true
       FEATURE_FLAG_ORS_WASTE_BALANCE_VALIDATION: true
-      FEATURE_FLAG_OVERSEAS_SITES: true
-      FEATURE_FLAG_REGISTERED_ONLY: true
       FEATURE_FLAG_REPORTS: true
       GOVUK_NOTIFY_API_KEY: fake-key-for-testing
       LOCALSTACK_ENDPOINT: http://localstack:4566
@@ -222,7 +220,6 @@ services:
       DEFRA_ID_OIDC_CONFIGURATION_URL: http://defra-id-stub:3200/cdp-defra-id-stub/.well-known/openid-configuration
       DEFRA_ID_SERVICE_ID: d7d72b79-9c62-ee11-8df0-000d3adf7047
       EPR_BACKEND_URL: http://epr-backend:3001
-      FEATURE_FLAG_REGISTERED_ONLY: true
       FEATURE_FLAG_REPORTS: true
       LOCALSTACK_ENDPOINT: http://localstack:4566
       NODE_ENV: development


### PR DESCRIPTION
Ticket: [PAE-1330](https://eaflood.atlassian.net/browse/PAE-1330)
## Summary

Remove `FEATURE_FLAG_OVERSEAS_SITES` and `FEATURE_FLAG_REGISTERED_ONLY` environment variables from the Docker Compose service definitions for `epr-backend` and `epr-frontend`.

These feature flags are being removed from the service code — the functionality they guarded is now permanently enabled. The test compose configuration no longer needs to set them.

[PAE-1330]: https://eaflood.atlassian.net/browse/PAE-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ