### PR TITLE
PAE-1335: Update accredited back-link tests to expect reports list

### DIFF
--- a/test/specs/accredited.exporter.report.e2e.js
+++ b/test/specs/accredited.exporter.report.e2e.js
@@ -80,13 +80,14 @@ describe('Accredited exporter report flow @accreditedExporter', () => {
       await ReportsPage.selectActionLink(1)
       await ReportDetailPage.useThisData()
 
-      // On prn-summary — back link goes to detail page
+      // On prn-summary — back link goes to reports list
       await PrnSummaryPage.selectBackLink()
-      const detailHeading = await ReportDetailPage.headingText()
-      expect(detailHeading).toBeTruthy()
+      const reportsHeading = await ReportsPage.headingText()
+      expect(reportsHeading).toContain('Reports')
 
-      // Go forward again
-      await ReportDetailPage.useThisData()
+      // Re-enter the wizard — report is in_progress so the action link
+      // routes straight to prn-summary
+      await ReportsPage.selectActionLink(1)
 
       // Continue to free-perns
       await PrnSummaryPage.enterRevenue('100')

--- a/test/specs/accredited.reprocessor.report.e2e.js
+++ b/test/specs/accredited.reprocessor.report.e2e.js
@@ -90,13 +90,14 @@ describe('Accredited reprocessor report flow @accreditedReprocessor', () => {
       await ReportsPage.selectActionLink(1)
       await ReportDetailPage.useThisData()
 
-      // On tonnes-recycled — back link goes to detail page
+      // On tonnes-recycled — back link goes to reports list
       await TonnesRecycledPage.selectBackLink()
-      const detailHeading = await ReportDetailPage.headingText()
-      expect(detailHeading).toBeTruthy()
+      const reportsHeading = await ReportsPage.headingText()
+      expect(reportsHeading).toContain('Reports')
 
-      // Go forward again
-      await ReportDetailPage.useThisData()
+      // Re-enter the wizard — report is in_progress so the action link
+      // routes straight to tonnes-recycled
+      await ReportsPage.selectActionLink(1)
 
       // Continue to tonnes-not-recycled
       await TonnesRecycledPage.enterTonnage('15.02')

--- a/test/specs/registered.exporter.report.e2e.js
+++ b/test/specs/registered.exporter.report.e2e.js
@@ -152,13 +152,14 @@ describe('Registered-only exporter report flow @registeredOnlyExporter', () => {
     await ReportsPage.selectActionLink(1)
     await ReportDetailPage.useThisData()
 
-    // On tonnes-not-exported — back link goes to detail page
+    // On tonnes-not-exported — back link goes to reports list
     await TonnesNotExportedPage.selectBackLink()
-    const detailHeading = await ReportDetailPage.headingText()
-    expect(detailHeading).toBeTruthy()
+    const reportsHeading = await ReportsPage.headingText()
+    expect(reportsHeading).toContain('Reports')
 
-    // Go forward again
-    await ReportDetailPage.useThisData()
+    // Re-enter the wizard — report is in_progress so the action link
+    // routes straight to tonnes-not-exported
+    await ReportsPage.selectActionLink(1)
 
     // Continue to tonnage not exported page
     await TonnesNotExportedPage.enterTonnage('5.50')

--- a/test/specs/registered.reprocessor.report.e2e.js
+++ b/test/specs/registered.reprocessor.report.e2e.js
@@ -164,13 +164,14 @@ describe('Registered-only reprocessor report flow @registeredOnlyReprocessor', (
     await ReportsPage.selectActionLink(1)
     await ReportDetailPage.useThisData()
 
-    // On tonnes-recycled — back link goes to detail page
+    // On tonnes-recycled — back link goes to reports list
     await TonnesRecycledPage.selectBackLink()
-    const detailHeading = await ReportDetailPage.headingText()
-    expect(detailHeading).toBeTruthy()
+    const reportsHeading = await ReportsPage.headingText()
+    expect(reportsHeading).toContain('Reports')
 
-    // Go forward again
-    await ReportDetailPage.useThisData()
+    // Re-enter the wizard — report is in_progress so the action link
+    // routes straight to tonnes-recycled
+    await ReportsPage.selectActionLink(1)
 
     // Continue to tonnes-not-recycled
     await TonnesRecycledPage.enterTonnage('12.50')


### PR DESCRIPTION
Ticket: [PAE-1335](https://eaflood.atlassian.net/browse/PAE-1335)
## Summary
Four journey test specs were encoding an old behaviour where the in-page "Back" link on the first wizard step of each reporting flow landed on the agree-and-proceed page. After the frontend fix that prevents re-rendering the agree-and-proceed page once a report exists and repoints the first-step back links at the reports list, these specs have been updated to match.

## What Changed
- Updated the first back-link assertion in all four reporting flow specs (accredited reprocessor, accredited exporter, registered-only exporter, registered-only reprocessor) to expect the reports list page rather than the agree-and-proceed page.
- Updated the subsequent "re-enter the wizard" step in those tests to use the reports list action link rather than clicking "Use this data" again.
- The registered-only reprocessor back-link spec is currently skipped due to an unrelated timing issue, but has been updated in this pass to avoid leaving a stale assertion that would trip the test as soon as it is un-skipped.

## Why
The frontend change in the companion PR stops the agree-and-proceed page from re-rendering once a report exists, and repoints the first-step back links at the reports list instead. These journey tests were asserting the old behaviour and would fail against the updated frontend until this change lands alongside it.

[PAE-1335]: https://eaflood.atlassian.net/browse/PAE-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ