### PR TITLE
PAE-1342: add check-answers guard e2e tests and enable registered reprocessor flow

### DIFF
--- a/test/specs/accredited.exporter.report.e2e.js
+++ b/test/specs/accredited.exporter.report.e2e.js
@@ -253,6 +253,15 @@ describe('Accredited exporter report flow @accreditedExporter', () => {
       // Close draft tab and return to confirmation page
       await closeCurrentTabAndReturn(originalTab)
     })
+
+    it('should redirect to reports list when navigating back to check-answers after report is created @accreditedExporterCheckAnswersGuard', async () => {
+      // Report is now ready_to_submit. Navigating back to check-answers
+      // should redirect to the reports list, not show the form again.
+      await browser.back()
+
+      const reportsHeading = await ReportsPage.headingText()
+      expect(reportsHeading).toContain('Reports')
+    })
   })
 
   describe('non-accredited exporter route guards', () => {

--- a/test/specs/accredited.reprocessor.report.e2e.js
+++ b/test/specs/accredited.reprocessor.report.e2e.js
@@ -323,6 +323,15 @@ describe('Accredited reprocessor report flow @accreditedReprocessor', () => {
       // Close draft tab and return to confirmation page
       await closeCurrentTabAndReturn(originalTab)
     })
+
+    it('should redirect to reports list when navigating back to check-answers after report is created @accreditedReprocessorCheckAnswersGuard', async () => {
+      // Report is now ready_to_submit. Navigating back to check-answers
+      // should redirect to the reports list, not show the form again.
+      await browser.back()
+
+      const reportsHeading = await ReportsPage.headingText()
+      expect(reportsHeading).toContain('Reports')
+    })
   })
 
   describe('non-accredited reprocessor route guard', () => {

--- a/test/specs/registered.exporter.report.e2e.js
+++ b/test/specs/registered.exporter.report.e2e.js
@@ -23,6 +23,16 @@ import {
 
 const REG_NUMBER = 'E25SR500030913PA'
 
+async function uploadAndNavigateToReports() {
+  await DashboardPage.selectTableLink(1, 1)
+  await WasteRecordsPage.submitSummaryLogLink()
+  await UploadSummaryLogPage.performUploadAndReturnToHomepage(
+    'resources/exporter-regonly.xlsx'
+  )
+  await DashboardPage.selectTableLink(1, 1)
+  await WasteRecordsPage.manageReportsLink()
+}
+
 async function setupRegisteredOnlyExporter() {
   const organisationDetails = await createLinkedOrganisation([
     {
@@ -60,17 +70,7 @@ async function setupRegisteredOnlyExporter() {
 describe('Registered-only exporter report flow @registeredOnlyExporter', () => {
   it('should complete the full registered-only exporter report flow through to confirmation @registeredOnlyExporterFullFlow', async () => {
     await setupRegisteredOnlyExporter()
-
-    // Upload registered-only exporter summary log
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.submitSummaryLogLink()
-    await UploadSummaryLogPage.performUploadAndReturnToHomepage(
-      'resources/exporter-regonly.xlsx'
-    )
-
-    // Navigate to reports
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.manageReportsLink()
+    await uploadAndNavigateToReports()
 
     // Start the report — should redirect to tonnes-not-exported
     await ReportsPage.selectActionLink(1)
@@ -136,19 +136,33 @@ describe('Registered-only exporter report flow @registeredOnlyExporter', () => {
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
   })
 
+  it('should redirect to reports list when navigating back to check-answers after report is created @registeredOnlyExporterCheckAnswersGuard', async () => {
+    await setupRegisteredOnlyExporter()
+    await uploadAndNavigateToReports()
+
+    // Complete the full flow through to confirmation
+    await ReportsPage.selectActionLink(1)
+    await ReportDetailPage.useThisData()
+    await TonnesNotExportedPage.enterTonnage('5.50')
+    await TonnesNotExportedPage.continue()
+    await ReportSupportingInformationPage.continue()
+    await ReportCheckAnswersPage.createReport()
+    await checkBodyText('report created', 30)
+
+    // Navigate back to check-answers — the guard should redirect to the reports list
+    await browser.back()
+
+    const reportsHeading = await ReportsPage.headingText()
+    expect(reportsHeading).toContain('Reports')
+
+    await HomePage.signOut()
+    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+  })
+
   it('should navigate back correctly through the registered-only exporter flow @registeredOnlyExporterBackLinks', async () => {
     await setupRegisteredOnlyExporter()
+    await uploadAndNavigateToReports()
 
-    // Upload summary log
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.submitSummaryLogLink()
-    await UploadSummaryLogPage.performUploadAndReturnToHomepage(
-      'resources/exporter-regonly.xlsx'
-    )
-
-    // Navigate to reports and start report
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.manageReportsLink()
     await ReportsPage.selectActionLink(1)
     await ReportDetailPage.useThisData()
 

--- a/test/specs/registered.reprocessor.report.e2e.js
+++ b/test/specs/registered.reprocessor.report.e2e.js
@@ -24,6 +24,28 @@ import {
 
 const REG_NUMBER = 'R25SR5111050912PA'
 
+async function startAndSubmitReport() {
+  await ReportsPage.selectActionLink(1)
+  await ReportDetailPage.useThisData()
+  await TonnesRecycledPage.enterTonnage('12.50')
+  await TonnesRecycledPage.continue()
+  await TonnesNotRecycledPage.enterTonnage('7.50')
+  await TonnesNotRecycledPage.continue()
+  await ReportSupportingInformationPage.continue()
+  await ReportCheckAnswersPage.createReport()
+  await checkBodyText('report created', 30)
+}
+
+async function uploadAndNavigateToReports() {
+  await DashboardPage.selectTableLink(1, 1)
+  await WasteRecordsPage.submitSummaryLogLink()
+  await UploadSummaryLogPage.performUploadAndReturnToHomepage(
+    'resources/reprocessor-output-regonly.xlsx'
+  )
+  await DashboardPage.selectTableLink(1, 1)
+  await WasteRecordsPage.manageReportsLink()
+}
+
 async function setupRegisteredOnlyReprocessor() {
   const organisationDetails = await createLinkedOrganisation([
     {
@@ -60,21 +82,9 @@ async function setupRegisteredOnlyReprocessor() {
 }
 
 describe('Registered-only reprocessor report flow @registeredOnlyReprocessor', () => {
-  // Skip: registered-only reprocessors use quarterly cadence.
-  // Q1 2026 ends March 31 — no quarterly period is available until April 1.
-  it.skip('should complete the full registered-only reprocessor report flow through to confirmation @registeredOnlyReprocessorFullFlow', async () => {
+  it('should complete the full registered-only reprocessor report flow through to confirmation @registeredOnlyReprocessorFullFlow', async () => {
     await setupRegisteredOnlyReprocessor()
-
-    // Upload registered-only reprocessor summary log
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.submitSummaryLogLink()
-    await UploadSummaryLogPage.performUploadAndReturnToHomepage(
-      'resources/reprocessor-output-regonly.xlsx'
-    )
-
-    // Navigate to reports
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.manageReportsLink()
+    await uploadAndNavigateToReports()
 
     // Start the report — should redirect to tonnes-recycled
     await ReportsPage.selectActionLink(1)
@@ -106,9 +116,9 @@ describe('Registered-only reprocessor report flow @registeredOnlyReprocessor', (
     const checkHeading = await ReportCheckAnswersPage.headingText()
     expect(checkHeading).toBe('Check your answers before creating draft report')
 
-    // Verify recycling activity values displayed
-    await checkBodyText('12.50', 10)
-    await checkBodyText('7.50', 10)
+    // Verify recycling activity values displayed (rendered without formatTonnage, so no trailing zero)
+    await checkBodyText('12.5', 10)
+    await checkBodyText('7.5', 10)
 
     // Verify NO PRN section present
     await checkBodyTextDoesNotInclude('PRN revenue', 5)
@@ -147,20 +157,25 @@ describe('Registered-only reprocessor report flow @registeredOnlyReprocessor', (
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
   })
 
-  // Skip: same Q1 timing issue as full flow test above
-  it.skip('should navigate back correctly through the registered-only reprocessor flow @registeredOnlyReprocessorBackLinks', async () => {
+  it('should redirect to reports list when navigating back to check-answers after report is created @registeredOnlyReprocessorCheckAnswersGuard', async () => {
     await setupRegisteredOnlyReprocessor()
+    await uploadAndNavigateToReports()
+    await startAndSubmitReport()
 
-    // Upload summary log
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.submitSummaryLogLink()
-    await UploadSummaryLogPage.performUploadAndReturnToHomepage(
-      'resources/reprocessor-output-regonly.xlsx'
-    )
+    // Navigate back to check-answers — the guard should redirect to the reports list
+    await browser.back()
 
-    // Navigate to reports and start report
-    await DashboardPage.selectTableLink(1, 1)
-    await WasteRecordsPage.manageReportsLink()
+    const reportsHeading = await ReportsPage.headingText()
+    expect(reportsHeading).toContain('Reports')
+
+    await HomePage.signOut()
+    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+  })
+
+  it('should navigate back correctly through the registered-only reprocessor flow @registeredOnlyReprocessorBackLinks', async () => {
+    await setupRegisteredOnlyReprocessor()
+    await uploadAndNavigateToReports()
+
     await ReportsPage.selectActionLink(1)
     await ReportDetailPage.useThisData()
 


### PR DESCRIPTION
Ticket: [PAE-1342](https://eaflood.atlassian.net/browse/PAE-1342)
## Changes

- Add `@*CheckAnswersGuard` e2e test to all four report flows (accredited exporter, accredited reprocessor, registered-only exporter, registered-only reprocessor): complete the flow to confirmation, navigate back, assert redirect to reports list
- Enable previously-skipped registered-only reprocessor full-flow and back-links tests (Q1 2026 period now available)
- Extract `uploadAndNavigateToReports` and `startAndSubmitReport` helpers to remove duplication across tests
- Fix CYA assertion for reprocessor tonnage values — rendered without `formatTonnage` filter so no trailing zero (`12.5` not `12.50`)

[PAE-1342]: https://eaflood.atlassian.net/browse/PAE-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ