### PR TITLE
PAE-1343: Update delete test for new back-link and fix login race

### DIFF
--- a/test/page-objects/defra.id.stub.page.js
+++ b/test/page-objects/defra.id.stub.page.js
@@ -1,5 +1,21 @@
 import { browser, $, $$ } from '@wdio/globals'
 
+// Triggers a navigation via `click` and waits for the browser URL to
+// actually change before returning. Needed for the OAuth login flow: the
+// click kicks off a redirect chain (stub login page → stub org picker
+// and/or app callback → dashboard), and the session cookie is only set
+// once the chain has settled. A caller that issues browser.url(...) next
+// can otherwise race the chain and hit the app as unauthenticated, which
+// redirects to /logged-out and leaves the test staring at the wrong page.
+async function clickAndWaitForNavigation(click, timeoutMsg) {
+  const urlBeforeClick = await browser.getUrl()
+  await click()
+  await browser.waitUntil(
+    async () => (await browser.getUrl()) !== urlBeforeClick,
+    { timeout: 15000, timeoutMsg }
+  )
+}
+
 class DefraIdStubPage {
   constructor() {
     this.baseUrl = 'http://localhost:3200'
@@ -48,30 +64,19 @@ class DefraIdStubPage {
       },
       { timeout: 15000, interval: 2000 }
     )
-    await $(selector).click()
-
-    // The click triggers an OAuth redirect chain (stub → app callback →
-    // dashboard) that sets the userSession cookie on the way through. A
-    // caller that issues browser.url(...) next can race the chain and
-    // arrive before the cookie lands, so the request hits the app as
-    // unauthenticated. Wait until we've left the stub host to guarantee
-    // the chain has finished before returning.
-    await browser.waitUntil(
-      async () => {
-        const currentUrl = await browser.getUrl()
-        return !currentUrl.includes('defra-id-stub')
-      },
-      {
-        timeout: 15000,
-        timeoutMsg: 'Login did not redirect away from defra-id-stub'
-      }
+    await clickAndWaitForNavigation(
+      () => $(selector).click(),
+      'Login click did not trigger navigation'
     )
   }
 
   async selectOrganisation(index) {
     const suffix = index === 1 ? '' : `-${index}`
     await $(`#relationshipId${suffix}`).click()
-    await $('button[type=submit]').click()
+    await clickAndWaitForNavigation(
+      () => $('button[type=submit]').click(),
+      'Organisation submit did not trigger navigation'
+    )
   }
 }
 

--- a/test/page-objects/defra.id.stub.page.js
+++ b/test/page-objects/defra.id.stub.page.js
@@ -49,6 +49,23 @@ class DefraIdStubPage {
       { timeout: 15000, interval: 2000 }
     )
     await $(selector).click()
+
+    // The click triggers an OAuth redirect chain (stub → app callback →
+    // dashboard) that sets the userSession cookie on the way through. A
+    // caller that issues browser.url(...) next can race the chain and
+    // arrive before the cookie lands, so the request hits the app as
+    // unauthenticated. Wait until we've left the stub host to guarantee
+    // the chain has finished before returning.
+    await browser.waitUntil(
+      async () => {
+        const currentUrl = await browser.getUrl()
+        return !currentUrl.includes('defra-id-stub')
+      },
+      {
+        timeout: 15000,
+        timeoutMsg: 'Login did not redirect away from defra-id-stub'
+      }
+    )
   }
 
   async selectOrganisation(index) {

--- a/test/specs/delete.report.e2e.js
+++ b/test/specs/delete.report.e2e.js
@@ -135,19 +135,17 @@ describe('Deleting an in-progress report', () => {
     expect(checkHeading).toBe('Check your answers before creating draft report')
     await ReportCheckAnswersPage.deleteAndStartAgainLink()
 
-    // Confirm deletion page — test back link goes to supporting information
+    // Confirm deletion page — test back link returns to check your answers
     deleteHeading = await ConfirmDeleteReportPage.headingText()
     expect(deleteHeading).toBe('Confirm deletion of this report')
 
     await ConfirmDeleteReportPage.selectBackLink()
-    const backToSupportingInfo =
-      await ReportSupportingInformationPage.headingText()
-    expect(backToSupportingInfo).toBe(
-      'Add supporting information for your regulator (optional)'
+    const backToCheckAnswers = await ReportCheckAnswersPage.headingText()
+    expect(backToCheckAnswers).toBe(
+      'Check your answers before creating draft report'
     )
 
-    // Navigate back to check answers and delete
-    await ReportSupportingInformationPage.continue()
+    // Return to confirm deletion and delete
     await ReportCheckAnswersPage.deleteAndStartAgainLink()
     await ConfirmDeleteReportPage.confirmDeletion()
 


### PR DESCRIPTION
Ticket: [PAE-1343](https://eaflood.atlassian.net/browse/PAE-1343)
## Summary
Two fixes to the journey tests: one to align the delete-report spec with the new delete-confirmation back-link behaviour, and one to close a race in the Defra ID stub login helper that was causing intermittent failures for any test that navigated to a direct URL immediately after login.

## What Changed
- Update the delete-from-check-your-answers assertion to expect the confirm-delete back link to return to check your answers (its referring page) instead of supporting information.
- Extend `DefraIdStubPage.loginViaEmail` to wait for the browser to leave the stub host before returning, so the OAuth redirect chain has finished and the session cookie is in place.

## Why
The frontend back-link logic now honours the actual referring page, so the delete test's old assertion no longer holds.

Separately, clicking the login link kicks off an OAuth redirect chain through the stub and back to the app, and the original helper returned immediately after the click. Any test that followed up with `browser.url(...)` could race the chain and hit the app before the session cookie was set, getting redirected to `/logged-out` instead of the expected page. Waiting for the redirect to complete makes login deterministic and eliminates a flake that had been poisoning downstream tests in the same spec.

[PAE-1343]: https://eaflood.atlassian.net/browse/PAE-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ