### PR TITLE
PAE-000: pin selenium-chrome platform

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -25,6 +25,7 @@ services:
   # containers.
   selenium-chrome:
     image: selenium/standalone-chrome:145.0
+    platform: linux/amd64
     ports:
       - 4444:4444
     environment:


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
selenium 145 ships amd64-only; pinning the platform unblocks pulls on arm64 hosts.