### PR TITLE
PAE-1349: add journey tests for registration number on detail page and site on submit page

### DIFF
--- a/test/specs/accredited.reprocessor.report.e2e.js
+++ b/test/specs/accredited.reprocessor.report.e2e.js
@@ -312,6 +312,7 @@ describe('Accredited reprocessor report flow @accreditedReprocessor', () => {
       await checkBodyText('Ready to submit', 10)
       await checkBodyText('Created by:', 10)
       await checkBodyText('Created on:', 10)
+      await checkBodyText('Site', 10)
       await checkBodyText('Packaging waste received for reprocessing', 10)
       await checkBodyText('Packaging waste recycling', 10)
       await checkBodyText('Packaging waste sent on', 10)

--- a/test/specs/registered.reprocessor.report.e2e.js
+++ b/test/specs/registered.reprocessor.report.e2e.js
@@ -86,8 +86,9 @@ describe('Registered-only reprocessor report flow @registeredOnlyReprocessor', (
     await setupRegisteredOnlyReprocessor()
     await uploadAndNavigateToReports()
 
-    // Start the report — should redirect to tonnes-recycled
+    // Start the report — verify registration number visible on detail page
     await ReportsPage.selectActionLink(1)
+    await checkBodyText(REG_NUMBER, 10)
     await ReportDetailPage.useThisData()
 
     // --- Tonnes recycled page ---


### PR DESCRIPTION
Ticket: [PAE-1349](https://eaflood.atlassian.net/browse/PAE-1349)
- Assert registration number is visible on the report detail page for registered-only reprocessors
- Assert Site label appears in the draft report summary list for accredited reprocessors

[PAE-1349]: https://eaflood.atlassian.net/browse/PAE-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ