### PR TITLE
PAE-000: Fix fast-xml-parser vulnerability and prune stale overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1305,6 +1305,18 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@open-draft/until": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
@@ -5116,9 +5128,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -5131,9 +5143,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.7",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
-      "integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -5142,9 +5154,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -8657,9 +8670,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -10204,9 +10217,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -51,9 +51,6 @@
     "undici": "7.24.5"
   },
   "overrides": {
-    "basic-ftp": "5.3.0",
-    "follow-redirects": "1.16.0",
-    "protobufjs": "7.5.5",
     "serialize-javascript": "7.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
Updates `fast-xml-parser` via `npm audit fix` to patch GHSA-gh4j-gqv2-49f6 (XML Comment and CDATA Injection via Unescaped Delimiters). The vulnerable version was pulled transitively by `@wdio/cli > @wdio/utils > edgedriver`, and the semver-compatible bump resolves it without any package.json changes beyond the override pruning below.

While here, prunes three overrides that no longer do anything: `basic-ftp` at 5.3.0, `follow-redirects` at 1.16.0, and `protobufjs` at 7.5.5. Each was verified by removing it, resolving the lockfile, and confirming neither `npm audit` nor `snyk test` flagged anything new.

The `serialize-javascript` override at 7.0.5 is retained — removing it lets `@wdio/mocha-framework > mocha` pull in a vulnerable version (SNYK-JS-SERIALIZEJAVASCRIPT-15809196 and SNYK-JS-SERIALIZEJAVASCRIPT-570062).

The remaining `uuid <14.0.0` advisory (GHSA-w5hq-g745-h8pq) is out of scope — it is transitive via `@wdio/browserstack-service > @browserstack/ai-sdk-node` and the only `npm audit fix --force` path downgrades `@wdio/browserstack-service` to 8.0.14 which is a breaking change.