### PR TITLE
PAE-250: Fix uuid vulnerability via override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,19 +86,6 @@
         "uuid": "9.0.1"
       }
     },
-    "node_modules/@browserstack/ai-sdk-node/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@browserstack/wdio-browserstack-service": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@browserstack/wdio-browserstack-service/-/wdio-browserstack-service-2.0.2.tgz",
@@ -10789,16 +10776,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "overrides": {
     "serialize-javascript": "7.0.5",
-    "uuid": "^14.0.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "eslint": "9.39.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "undici": "7.24.5"
   },
   "overrides": {
-    "serialize-javascript": "7.0.5"
+    "serialize-javascript": "7.0.5",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "eslint": "9.39.4",


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
The `uuid` package below 14.0.0 has a missing buffer bounds check in v3/v5/v6 when `buf` is provided ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq), [SNYK-JS-UUID-16133035](https://security.snyk.io/vuln/SNYK-JS-UUID-16133035)). It reaches this repo transitively via `@wdio/browserstack-service` → `@browserstack/ai-sdk-node`, which are used for WebdriverIO browser-based journey tests.

Neither package has yet updated its `uuid` range, so this pins `uuid` to `^14.0.0` via an `overrides` entry in `package.json`. Both consumers use `uuid.v4()` only, which is unchanged in v14.

After the override, `npm audit` and `snyk test` both report zero vulnerable paths, and the Dependabot alert will close.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ