### PR TITLE
PAE-250: Fix axios vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2893,9 +2893,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "undici": "7.24.5"
   },
   "overrides": {
+    "axios": "1.15.2",
     "serialize-javascript": "7.0.5",
     "uuid": "14.0.0"
   },


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Pins `axios` to 1.15.2 via `overrides` to fix 12 Snyk advisories pulled in transitively via `@wdio/browserstack-service > @browserstack/ai-sdk-node > axios@1.15.0`, including:

- **Critical** — [HTTP Response Splitting](https://security.snyk.io/vuln/SNYK-JS-AXIOS-16298058)
- **Critical** — [Prototype Pollution](https://security.snyk.io/vuln/SNYK-JS-AXIOS-16299904)
- **High** — [Improperly Controlled Modification of Dynamically-Determined Object Attributes](https://security.snyk.io/vuln/SNYK-JS-AXIOS-16299921) (only fixed in 1.15.2, hence the choice of pin)
- **High** — [Uncontrolled Recursion](https://security.snyk.io/vuln/SNYK-JS-AXIOS-16299923)
- 8 further medium-severity issues (CRLF injection, SSRF, prototype pollution, sensitive-data leakage, allocation throttling)

The existing `serialize-javascript: 7.0.5` and `uuid: 14.0.0` overrides were checked for staleness — both still load-bearing, so kept.

## Verification

`npm audit` reports `0 vulnerabilities`; `snyk test` reports no vulnerable paths. `npm ls axios` confirms the override applied.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ