### PR TITLE
PAE-1339: Add advisory type checking to CI

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -40,6 +40,52 @@ jobs:
           npm run format:check
           npm run lint
 
+  type-check:
+    name: Lint Types (advisory)
+    runs-on: ubuntu-latest
+    needs: pr-prep
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Upgrade npm
+        run: npm install -g npm@11.12.1
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Lint types
+        run: |
+          OUTPUT=$(npm run lint:types 2>&1) && STATUS=0 || STATUS=$?
+          echo "$OUTPUT"
+
+          ERRORS=$(echo "$OUTPUT" | grep -cE "^(test|docker)/" || true)
+
+          {
+            if [ "$STATUS" -eq 0 ]; then
+              echo "## Lint Types"
+              echo ""
+              echo ":white_check_mark: Type check passed"
+            else
+              echo "## Lint Types"
+              echo ""
+              echo ":warning: **${ERRORS} type errors found** (advisory — not blocking)"
+              echo ""
+              echo "<details><summary>Errors by file</summary>"
+              echo ""
+              echo '```'
+              echo "$OUTPUT" | grep -E "^(test|docker)/" | sed 's/(.*/:/' | sort | uniq -c | sort -rn
+              echo '```'
+              echo "</details>"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   docker-build:
     name: Docker Build
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -62,29 +62,11 @@ jobs:
 
       - name: Lint types
         run: |
-          OUTPUT=$(npm run lint:types 2>&1) && STATUS=0 || STATUS=$?
-          echo "$OUTPUT"
-
-          ERRORS=$(echo "$OUTPUT" | grep -cE "^(test|docker)/" || true)
-
-          {
-            if [ "$STATUS" -eq 0 ]; then
-              echo "## Lint Types"
-              echo ""
-              echo ":white_check_mark: Type check passed"
-            else
-              echo "## Lint Types"
-              echo ""
-              echo ":warning: **${ERRORS} type errors found** (advisory — not blocking)"
-              echo ""
-              echo "<details><summary>Errors by file</summary>"
-              echo ""
-              echo '```'
-              echo "$OUTPUT" | grep -E "^(test|docker)/" | sed 's/(.*/:/' | sort | uniq -c | sort -rn
-              echo '```'
-              echo "</details>"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+          if npm run lint:types; then
+            echo "::notice::Type check passed"
+          else
+            echo "::warning::Type check found errors (advisory — not blocking)"
+          fi
 
   docker-build:
     name: Docker Build

--- a/jsconfig.typecheck.json
+++ b/jsconfig.typecheck.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es2024",
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": false,
+    "noImplicitAny": false,
+    "strictNullChecks": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"],
+      "page-objects/*": ["./test/page-objects/*"],
+      "components/*": ["./test/components/*"]
+    }
+  },
+  "include": ["test/**/*.js", "docker/mock/**/*.js"],
+  "exclude": ["node_modules", "archived_form_tests"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,7 @@
         "husky": "9.1.7",
         "lint-staged": "16.4.0",
         "neostandard": "0.13.0",
-        "prettier": "3.8.1",
-        "typescript": "5.9.3"
+        "prettier": "3.8.1"
       },
       "engines": {
         "node": ">=24.14.1 <25.0.0",
@@ -10666,6 +10665,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "husky": "9.1.7",
         "lint-staged": "16.4.0",
         "neostandard": "0.13.0",
-        "prettier": "3.8.1"
+        "prettier": "3.8.1",
+        "typescript": "5.9.3"
       },
       "engines": {
         "node": ">=24.14.1 <25.0.0",
@@ -10665,7 +10666,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "format:check": "prettier --check 'test/**/*.js' '**/*.{js,md,json,config.js}'",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "lint:types": "tsc -p jsconfig.typecheck.json",
     "postinstall": "npm run setup:husky",
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module",
     "report": "allure generate allure-results --single-file --clean",
@@ -63,6 +64,7 @@
     "husky": "9.1.7",
     "lint-staged": "16.4.0",
     "neostandard": "0.13.0",
-    "prettier": "3.8.1"
+    "prettier": "3.8.1",
+    "typescript": "5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "husky": "9.1.7",
     "lint-staged": "16.4.0",
     "neostandard": "0.13.0",
-    "prettier": "3.8.1",
-    "typescript": "5.9.3"
+    "prettier": "3.8.1"
   }
 }


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)

## Summary

Introduces type checking as an advisory CI step for this repo, mirroring PAE-1339's rollout in [epr-backend-journey-tests #441](https://github.com/DEFRA/epr-backend-journey-tests/pull/441) and [epr-frontend #765](https://github.com/DEFRA/epr-frontend/pull/765).

- `jsconfig.typecheck.json` at repo root covers `test/**/*.js` and `docker/mock/**/*.js` with `allowJs` / `checkJs` / `strictNullChecks` on, `noImplicitAny` off — matches the broader rollout's starting posture. Path aliases (`~`, `page-objects`, `components`) are mirrored from `jsconfig.json` so the type checker can resolve the codebase's own imports. `archived_form_tests/` is excluded.
- `lint:types` script added to `package.json`. `typescript` resolves transitively via `@wdio` packages (matches epr-backend-journey-tests).
- A new `Lint Types (advisory)` job in the PR workflow runs the script; it raises a GitHub `::warning::` annotation when type errors are present without failing the build.

Baseline on `main` at introduction: **27** type errors, dominated by `TS2353`, `TS2339` and `TS2345`. Fixing them is tracked separately; this PR only wires up the advisory step so the error count is visible on every PR. A follow-up will flip it to blocking once the count is at zero.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ