### PR TITLE
PAE-250: Prune stale axios override

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "undici": "7.24.5"
   },
   "overrides": {
-    "axios": "1.15.2",
     "serialize-javascript": "7.0.5",
     "uuid": "14.0.0"
   },


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Removes the `axios` entry from `package.json` `overrides` because it is no longer changing anything — `@wdio/browserstack-service@9.27.0 > @browserstack/ai-sdk-node@1.5.17` already pulls in `axios@1.15.2`, the same version the override was pinning.

The override was tested in isolation by removing it from `package.json`, regenerating the lockfile, and running both `npm audit` and `snyk test`. Both reported zero issues with the override gone.

The remaining overrides (`serialize-javascript`, `uuid`) were verified as still required: removing either of them causes `npm audit` to flag a vulnerability that the override was suppressing (`serialize-javascript` <=7.0.4 high via mocha; `uuid` <14.0.0 moderate buffer bounds check).

## Why prune it

The shared CI `Preparation` step rejects unpinned ranges in `overrides`, which means each entry is a permanent forced version that won't update with the rest of the tree until someone removes it. Stale overrides that no longer affect resolution add maintenance noise — they're easily mistaken for active mitigations during future audits and force the reviewer to verify why each one is still there. Pruning them keeps the override list a meaningful list of active mitigations.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ