### PR TITLE
PAE-250: Fix ip-address XSS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6134,9 +6134,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "undici": "7.24.5"
   },
   "overrides": {
+    "ip-address": "10.2.0",
     "serialize-javascript": "7.0.5",
     "uuid": "14.0.0"
   },


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
Pin `ip-address` to `10.2.0` via npm overrides to address [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) — `Address6` HTML-emitting helpers are vulnerable to XSS for versions `<=10.1.0`.

`ip-address` is a transitive dependency reached through `@wdio/cli > @wdio/utils > @puppeteer/browsers > proxy-agent > socks-proxy-agent > socks`. None of those parents have shipped a release that bumps to a patched range yet, so the override is the cleanest way to silence `npm audit` without waiting on the upstream chain.

Real-world impact in this repo is nil — it's a test-only project that doesn't render any of `Address6`'s output to a browser — but the override keeps audit clean and removes a recurring noise source from future runs.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ