### PR TITLE
PAE-1381: Add unsubmit report test to Frontend tests

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -208,6 +208,7 @@ services:
       FEATURE_FLAG_DEV_ENDPOINTS: true
       FEATURE_FLAG_ORS_WASTE_BALANCE_VALIDATION: true
       FEATURE_FLAG_REPORTS: true
+      FEATURE_FLAG_REPORT_UNSUBMIT: true
       GOVUK_NOTIFY_API_KEY: fake-key-for-testing
       MONGO_URI: mongodb://mongodb:27017/
       NODE_ENV: development

--- a/test/specs/accredited.exporter.report.e2e.js
+++ b/test/specs/accredited.exporter.report.e2e.js
@@ -15,6 +15,7 @@ import {
   createAndRegisterDefraIdUser,
   createLinkedOrganisation,
   linkDefraIdUser,
+  unsubmitReport,
   updateMigratedOrganisation
 } from '../support/apicalls.js'
 import { checkBodyText } from '../support/checks.js'
@@ -28,18 +29,20 @@ import ReportSubmittedPage from 'page-objects/reports/report.submitted.page.js'
 
 describe('Accredited exporter report flow @accreditedExporter', () => {
   describe('accredited exporter with upload', () => {
+    let organisationDetails
+    let migrationResponse
     before(async () => {
       const regNumber = 'E25SR500020912PA'
       const accNumber = 'E-ACC12245PA'
 
-      const organisationDetails = await createLinkedOrganisation([
+      organisationDetails = await createLinkedOrganisation([
         {
           material: 'Paper or board (R3)',
           wasteProcessingType: 'Exporter'
         }
       ])
 
-      const migrationResponse = await updateMigratedOrganisation(
+      migrationResponse = await updateMigratedOrganisation(
         organisationDetails.refNo,
         [
           {
@@ -288,8 +291,23 @@ describe('Accredited exporter report flow @accreditedExporter', () => {
 
       await ReportSubmittedPage.returnToReportsLink()
 
-      const statusBadge = await ReportsPage.getStatusBadge(1)
+      let statusBadge = await ReportsPage.getStatusBadge(1)
       expect(statusBadge).toBe('Submitted')
+
+      // Now we unsubmit the report via epr-backend to see the effects on the frontend
+      await unsubmitReport(
+        organisationDetails.refNo,
+        migrationResponse.registrationIds[0],
+        2026,
+        'monthly',
+        1
+      )
+
+      // Refresh to see the status change
+      await browser.refresh()
+
+      statusBadge = await ReportsPage.getStatusBadge(1)
+      expect(statusBadge).toBe('Ready to submit')
     })
   })
 

--- a/test/specs/accredited.reprocessor.report.e2e.js
+++ b/test/specs/accredited.reprocessor.report.e2e.js
@@ -247,7 +247,7 @@ describe('Accredited reprocessor report flow @accreditedReprocessor', () => {
       await ConfirmDeleteReportPage.confirmDeletion()
     })
 
-    it('should complete the full accredited reprocessor report flow through to confirmation with submission and unsubmission via backend @accreditedReprocessorFullFlow', async () => {
+    it('should complete the full accredited reprocessor report flow through to confirmation with submission and unsubmission via backend @accreditedReprocessorFullFlow @smoketest', async () => {
       await ReportsPage.selectActionLink(1)
       await ReportDetailPage.useThisData()
 

--- a/test/specs/accredited.reprocessor.report.e2e.js
+++ b/test/specs/accredited.reprocessor.report.e2e.js
@@ -17,6 +17,7 @@ import {
   createAndRegisterDefraIdUser,
   createLinkedOrganisation,
   linkDefraIdUser,
+  unsubmitReport,
   updateMigratedOrganisation
 } from '../support/apicalls.js'
 import { checkBodyText } from '../support/checks.js'
@@ -78,8 +79,9 @@ async function uploadAndNavigateToReports() {
 
 describe('Accredited reprocessor report flow @accreditedReprocessor', () => {
   describe('accredited reprocessor with upload', () => {
+    let setupResponse
     before(async () => {
-      await setupAccreditedReprocessor()
+      setupResponse = await setupAccreditedReprocessor()
       await uploadAndNavigateToReports()
     })
 
@@ -245,7 +247,7 @@ describe('Accredited reprocessor report flow @accreditedReprocessor', () => {
       await ConfirmDeleteReportPage.confirmDeletion()
     })
 
-    it('should complete the full accredited reprocessor report flow through to confirmation @accreditedReprocessorFullFlow', async () => {
+    it('should complete the full accredited reprocessor report flow through to confirmation with submission and unsubmission via backend @accreditedReprocessorFullFlow', async () => {
       await ReportsPage.selectActionLink(1)
       await ReportDetailPage.useThisData()
 
@@ -364,8 +366,23 @@ describe('Accredited reprocessor report flow @accreditedReprocessor', () => {
 
       await ReportSubmittedPage.returnToReportsLink()
 
-      const statusBadge = await ReportsPage.getStatusBadge(1)
+      let statusBadge = await ReportsPage.getStatusBadge(1)
       expect(statusBadge).toBe('Submitted')
+
+      // Now we unsubmit the report via epr-backend to see the effects on the frontend
+      await unsubmitReport(
+        setupResponse.organisationDetails.refNo,
+        setupResponse.migrationResponse.registrationIds[0],
+        2026,
+        'monthly',
+        1
+      )
+
+      // Refresh to see the status change
+      await browser.refresh()
+
+      statusBadge = await ReportsPage.getStatusBadge(1)
+      expect(statusBadge).toBe('Ready to submit')
     })
   })
 

--- a/test/specs/registered.exporter.report.e2e.js
+++ b/test/specs/registered.exporter.report.e2e.js
@@ -14,6 +14,7 @@ import {
   createAndRegisterDefraIdUser,
   createLinkedOrganisation,
   linkDefraIdUser,
+  unsubmitReport,
   updateMigratedOrganisation
 } from '../support/apicalls.js'
 import {
@@ -76,7 +77,7 @@ async function setupRegisteredOnlyExporter() {
 
 describe('Registered-only exporter report flow @registeredOnlyExporter', () => {
   it('should complete the full registered-only exporter report flow through to confirmation @registeredOnlyExporterFullFlow', async () => {
-    await setupRegisteredOnlyExporter()
+    const setupResponse = await setupRegisteredOnlyExporter()
     await uploadAndNavigateToReports()
 
     // Start the report — should redirect to tonnes-not-exported
@@ -159,8 +160,24 @@ describe('Registered-only exporter report flow @registeredOnlyExporter', () => {
     await closeCurrentTabAndReturn(originalTab)
 
     await ReportSubmittedPage.returnToReportsLink()
-    const statusBadge = await ReportsPage.getStatusBadge(1)
+    let statusBadge = await ReportsPage.getStatusBadge(1)
     expect(statusBadge).toBe('Submitted')
+
+    // Now we unsubmit the report via epr-backend to see the effects on the frontend
+    await unsubmitReport(
+      setupResponse.organisationDetails.refNo,
+      setupResponse.migrationResponse.registrationIds[0],
+      2026,
+      'quarterly',
+      1
+    )
+
+    // Refresh to see the status change
+    await browser.refresh()
+
+    statusBadge = await ReportsPage.getStatusBadge(1)
+    expect(statusBadge).toBe('Ready to submit')
+
     await HomePage.signOut()
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
   })

--- a/test/specs/registered.exporter.report.e2e.js
+++ b/test/specs/registered.exporter.report.e2e.js
@@ -76,7 +76,7 @@ async function setupRegisteredOnlyExporter() {
 }
 
 describe('Registered-only exporter report flow @registeredOnlyExporter', () => {
-  it('should complete the full registered-only exporter report flow through to confirmation @registeredOnlyExporterFullFlow', async () => {
+  it('should complete the full registered-only exporter report flow through to confirmation @registeredOnlyExporterFullFlow @smoketest', async () => {
     const setupResponse = await setupRegisteredOnlyExporter()
     await uploadAndNavigateToReports()
 

--- a/test/specs/registered.reprocessor.report.e2e.js
+++ b/test/specs/registered.reprocessor.report.e2e.js
@@ -15,6 +15,7 @@ import {
   createAndRegisterDefraIdUser,
   createLinkedOrganisation,
   linkDefraIdUser,
+  unsubmitReport,
   updateMigratedOrganisation
 } from '../support/apicalls.js'
 import {
@@ -90,7 +91,7 @@ async function setupRegisteredOnlyReprocessor() {
 
 describe('Registered-only reprocessor report flow @registeredOnlyReprocessor', () => {
   it('should complete the full registered-only reprocessor report flow through to confirmation @registeredOnlyReprocessorFullFlow', async () => {
-    await setupRegisteredOnlyReprocessor()
+    const setupResponse = await setupRegisteredOnlyReprocessor()
     await uploadAndNavigateToReports()
 
     // Start the report — verify registration number visible on detail page
@@ -184,8 +185,24 @@ describe('Registered-only reprocessor report flow @registeredOnlyReprocessor', (
 
     await ReportSubmittedPage.returnToReportsLink()
 
-    const statusBadge = await ReportsPage.getStatusBadge(1)
+    let statusBadge = await ReportsPage.getStatusBadge(1)
     expect(statusBadge).toBe('Submitted')
+
+    // Now we unsubmit the report via epr-backend to see the effects on the frontend
+    await unsubmitReport(
+      setupResponse.organisationDetails.refNo,
+      setupResponse.migrationResponse.registrationIds[0],
+      2026,
+      'quarterly',
+      1
+    )
+
+    // Refresh to see the status change
+    await browser.refresh()
+
+    statusBadge = await ReportsPage.getStatusBadge(1)
+    expect(statusBadge).toBe('Ready to submit')
+
     await HomePage.signOut()
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
   })

--- a/test/support/apicalls.js
+++ b/test/support/apicalls.js
@@ -428,6 +428,26 @@ export async function seedOverseasSites(orgRefNo, registrationIndex = 0) {
   expect(putResponse.statusCode).toBe(200)
 }
 
+export async function unsubmitReport(
+  organisationId,
+  registrationId,
+  year,
+  cadence,
+  period
+) {
+  const authClient = new AuthClient()
+  const eprBackend = new EprBackend()
+  await authClient.authenticate()
+  const unsubmitEndpoint = `/v1/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/unsubmit`
+  const response = await eprBackend.post(
+    unsubmitEndpoint,
+    '',
+    authClient.authHeader()
+  )
+
+  await assertSuccessResponseWithoutBody(response, `POST ${unsubmitEndpoint}`)
+}
+
 export async function externalAPICancelPrn(prnDetails) {
   await config.cognitoAuth.generateToken()
 


### PR DESCRIPTION
Ticket: [PAE-1381](https://eaflood.atlassian.net/browse/PAE-1381)
## Description

Add Unsubmit report test to 

Accredited reprocessor
Accredited exporter
Registered only reprocessor
Registered only exporter
 

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1381]: https://eaflood.atlassian.net/browse/PAE-1381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ