### PR TITLE
PAE-1446: add double-click prevention checks to PRN journey tests

### DIFF
--- a/test/page-objects/confirm.cancel.prn.page.js
+++ b/test/page-objects/confirm.cancel.prn.page.js
@@ -7,6 +7,12 @@ class ConfirmCancelPRNPage {
     return await element.getText()
   }
 
+  async preventDoubleClick() {
+    return await $('button[type=submit]').getAttribute(
+      'data-prevent-double-click'
+    )
+  }
+
   async confirmCancelPrn() {
     await $('button[type=submit]').click()
   }

--- a/test/page-objects/confirm.delete.prn.page.js
+++ b/test/page-objects/confirm.delete.prn.page.js
@@ -7,6 +7,12 @@ class ConfirmDeletePRNPage {
     return await element.getText()
   }
 
+  async preventDoubleClick() {
+    return await $('button[type=submit]').getAttribute(
+      'data-prevent-double-click'
+    )
+  }
+
   async deletePrn() {
     await $('button[type=submit]').click()
   }

--- a/test/page-objects/confirm.discard.prn.page.js
+++ b/test/page-objects/confirm.discard.prn.page.js
@@ -7,6 +7,12 @@ class ConfirmDiscardPRNPage {
     return await element.getText()
   }
 
+  async preventDoubleClick() {
+    return await $('button[type=submit]').getAttribute(
+      'data-prevent-double-click'
+    )
+  }
+
   async discardAndStartAgain() {
     await $('button[type=submit]').click()
   }

--- a/test/page-objects/create.prn.page.js
+++ b/test/page-objects/create.prn.page.js
@@ -31,6 +31,12 @@ class CreatePRNPage {
     await $('#recipient').setValue(producer)
   }
 
+  async preventDoubleClick() {
+    return await $('#main-content button[type=submit]').getAttribute(
+      'data-prevent-double-click'
+    )
+  }
+
   async continue() {
     await $('#main-content button[type=submit]').click()
   }

--- a/test/page-objects/prn.view.page.js
+++ b/test/page-objects/prn.view.page.js
@@ -48,6 +48,12 @@ class PRNViewPage {
     await $('#main-content > div > div > form > div > a').click()
   }
 
+  async issueButtonPreventsDoubleClick() {
+    return await $(
+      '#main-content > div > div > form > div > button'
+    ).getAttribute('data-prevent-double-click')
+  }
+
   async issuePRNButton() {
     await $('#main-content > div > div > form > div > button').click()
   }

--- a/test/specs/create.prn.unhappy.paths.e2e.js
+++ b/test/specs/create.prn.unhappy.paths.e2e.js
@@ -75,6 +75,7 @@ describe('Creating Packing Recycling Notes', () => {
     await CheckBeforeCreatingPrnPage.discardAndStartAgain()
     const discardHeading = await ConfirmDiscardPRNPage.headingText()
     expect(discardHeading).toBe('Are you sure you want to discard this PRN?')
+    expect(await ConfirmDiscardPRNPage.preventDoubleClick()).toBe('true')
     await ConfirmDiscardPRNPage.discardAndStartAgain()
 
     prnDetails.issuerNotes = 'Testing'
@@ -92,6 +93,7 @@ describe('Creating Packing Recycling Notes', () => {
     let materialDetails = await CreatePRNPage.materialDetails()
     expect(materialDetails).toBe('Material: Paper and board')
 
+    expect(await CreatePRNPage.preventDoubleClick()).toBe('true')
     await CreatePRNPage.continue()
 
     let errorMessages = await CreatePRNPage.errorMessages(2)

--- a/test/specs/delete.prn.output.e2e.js
+++ b/test/specs/delete.prn.output.e2e.js
@@ -124,6 +124,7 @@ describe('Deleting Packing Recycling Notes (Reprocessor Output)', () => {
     expect(confirmDeleteHeadingText).toBe(
       'Are you sure you want to delete this PRN?'
     )
+    expect(await ConfirmDeletePRNPage.preventDoubleClick()).toBe('true')
     await ConfirmDeletePRNPage.deletePrn()
 
     const noCreatedPrnMessage = await PrnDashboardPage.getNoCreatedPrnMessage()

--- a/test/specs/issue.and.accept.prn.output.e2e.js
+++ b/test/specs/issue.and.accept.prn.output.e2e.js
@@ -92,6 +92,7 @@ describe('Issuing Packing Recycling Notes', () => {
 
     // Issue the created PRN
     await PrnDashboardPage.selectAwaitingLink(1)
+    expect(await PrnViewPage.issueButtonPreventsDoubleClick()).toBe('true')
     await prnHelper.issuePrnAndUpdateDetails(prnDetails, 'WR')
 
     await PrnIssuedPage.viewPdfButton()

--- a/test/specs/issue.and.reject.prn.input.e2e.js
+++ b/test/specs/issue.and.reject.prn.input.e2e.js
@@ -245,6 +245,7 @@ describe('Issuing Packing Recycling Notes', () => {
 
     const confirmCancelHeading = await ConfirmCancelPrnPage.headingText()
     expect(confirmCancelHeading).toBe('Confirm cancellation of this PRN')
+    expect(await ConfirmCancelPrnPage.preventDoubleClick()).toBe('true')
     await ConfirmCancelPrnPage.selectBackLink()
 
     // Now cancel the PRN and return to PRN Dashboard page


### PR DESCRIPTION
Ticket: [PAE-1446](https://eaflood.atlassian.net/browse/PAE-1446)
## Description

- Adds journey test coverage for double-click prevention on PRN action buttons
- Adds `preventDoubleClick()` / `issueButtonPreventsDoubleClick()` methods to five page objects to read the `data-prevent-double-click` attribute
- Asserts the attribute is present (`"true"`) in four existing specs before each action button is clicked

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1446]: https://eaflood.atlassian.net/browse/PAE-1446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ