### PR TITLE
PAE-000: summary logs double click prevention tests

### DIFF
--- a/test/page-objects/upload.summary.log.page.js
+++ b/test/page-objects/upload.summary.log.page.js
@@ -47,6 +47,12 @@ class UploadSummaryLogPage {
     return await $('#main-content h1').getText()
   }
 
+  async confirmAndSubmitPreventsDoubleClick() {
+    return await $('#main-content button[type=submit]').getAttribute(
+      'data-prevent-double-click'
+    )
+  }
+
   async confirmAndSubmit() {
     await $('#main-content button[type=submit]').click()
   }

--- a/test/specs/summarylogs.exporter.e2e.js
+++ b/test/specs/summarylogs.exporter.e2e.js
@@ -70,6 +70,9 @@ describe('Summary Logs Exporter', () => {
     await checkBodyText('Your file is being checked', 30)
     await checkBodyText('Check before confirming upload', 60)
     await checkBodyText('2 new loads will be added to your waste balance', 10)
+    expect(
+      await UploadSummaryLogPage.confirmAndSubmitPreventsDoubleClick()
+    ).toBe('true')
     await UploadSummaryLogPage.confirmAndSubmit()
 
     await checkBodyText('Your waste records are being updated', 30)

--- a/test/specs/summarylogs.exporter.e2e.js
+++ b/test/specs/summarylogs.exporter.e2e.js
@@ -105,7 +105,9 @@ describe('Summary Logs Exporter', () => {
       '2 adjusted loads will be reflected in your waste balance',
       10
     )
-
+    expect(
+      await UploadSummaryLogPage.confirmAndSubmitPreventsDoubleClick()
+    ).toBe('true')
     await UploadSummaryLogPage.confirmAndSubmit()
 
     await checkBodyText('Your waste records are being updated', 30)

--- a/test/specs/summarylogs.registered.only.e2e.js
+++ b/test/specs/summarylogs.registered.only.e2e.js
@@ -184,6 +184,9 @@ describe('@registered-only', () => {
     await checkBodyText('Loads exported', 30)
     await checkBodyText('Loads sent on', 30)
     await checkBodyText('new loads have been added', 30)
+    expect(
+      await UploadSummaryLogPage.confirmAndSubmitPreventsDoubleClick()
+    ).toBe('true')
     await UploadSummaryLogPage.confirmAndSubmit()
 
     await checkBodyText('Summary log uploaded', 30)

--- a/test/specs/summarylogs.registered.only.e2e.js
+++ b/test/specs/summarylogs.registered.only.e2e.js
@@ -113,6 +113,9 @@ describe('@registered-only', () => {
     await checkBodyText('Loads received', 30)
     await checkBodyText('Loads sent on', 30)
     await checkBodyText('new loads have been added', 30)
+    expect(
+      await UploadSummaryLogPage.confirmAndSubmitPreventsDoubleClick()
+    ).toBe('true')
     await UploadSummaryLogPage.confirmAndSubmit()
 
     await checkBodyText('Summary log uploaded', 30)

--- a/test/specs/summarylogs.reprocessor.input.e2e.js
+++ b/test/specs/summarylogs.reprocessor.input.e2e.js
@@ -97,6 +97,9 @@ describe('Summary Logs Reprocessor Input', () => {
     await checkBodyText('Your file is being checked', 30)
 
     await checkBodyText('Check before confirming upload', 60)
+    expect(
+      await UploadSummaryLogPage.confirmAndSubmitPreventsDoubleClick()
+    ).toBe('true')
     await UploadSummaryLogPage.confirmAndSubmit()
 
     await checkBodyText('Your waste records are being updated', 30)

--- a/test/specs/summarylogs.reprocessor.output.e2e.js
+++ b/test/specs/summarylogs.reprocessor.output.e2e.js
@@ -68,6 +68,9 @@ describe('Summary Logs Reprocessor Output', () => {
 
     await checkBodyText('Check before confirming upload', 60)
     await checkBodyText('1 new load will be added to your waste balance', 30)
+    expect(
+      await UploadSummaryLogPage.confirmAndSubmitPreventsDoubleClick()
+    ).toBe('true')
     await UploadSummaryLogPage.confirmAndSubmit()
 
     await checkBodyText('Your waste records are being updated', 30)

--- a/test/specs/summarylogs.reprocessor.output.e2e.js
+++ b/test/specs/summarylogs.reprocessor.output.e2e.js
@@ -105,7 +105,9 @@ describe('Summary Logs Reprocessor Output', () => {
       '1 adjusted load will be reflected in your waste balance',
       30
     )
-
+    expect(
+      await UploadSummaryLogPage.confirmAndSubmitPreventsDoubleClick()
+    ).toBe('true')
     await UploadSummaryLogPage.confirmAndSubmit()
 
     await checkBodyText('Your waste records are being updated', 30)

--- a/test/specs/summarylogs.unhappy.paths.e2e.js
+++ b/test/specs/summarylogs.unhappy.paths.e2e.js
@@ -15,6 +15,8 @@ import {
   updateMigratedOrganisation,
   linkDefraIdUser
 } from '../support/apicalls.js'
+import { AuthClient } from '../support/auth.js'
+import { EprBackend } from '../apis/epr-backend.js'
 
 describe('Summary Logs - Unhappy paths @unhappyPaths', () => {
   it('Should get an error message with an empty Summary Log spreadsheet @emptyMessage', async () => {
@@ -276,6 +278,73 @@ describe('Summary Logs - Unhappy paths @unhappyPaths', () => {
       'Sorry, there is a problem with the service - try again later',
       60
     )
+
+    await HomePage.signOut()
+    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+  })
+
+  it('Should show conflict page when summary log is already being submitted @summLogsConflict', async () => {
+    const organisationDetails = await createLinkedOrganisation([
+      { material: 'Steel (R4)', wasteProcessingType: 'Reprocessor' }
+    ])
+
+    const migrationResponse = await updateMigratedOrganisation(
+      organisationDetails.refNo,
+      [
+        {
+          reprocessingType: 'output',
+          regNumber: 'R25SR500050912PA',
+          accNumber: 'ACC500591',
+          status: 'approved',
+          validFrom: '2026-01-01'
+        }
+      ]
+    )
+
+    const user = await createAndRegisterDefraIdUser(migrationResponse.email)
+    await linkDefraIdUser(
+      organisationDetails.refNo,
+      user.userId,
+      migrationResponse.email
+    )
+
+    await HomePage.open()
+    await HomePage.clickStartNow()
+
+    await DefraIdStubPage.loginViaEmail(migrationResponse.email)
+
+    await DashboardPage.selectLink(1)
+    await WasteRecordsPage.submitSummaryLogLink()
+
+    await UploadSummaryLogPage.uploadFile('resources/reprocessor-output.xlsx')
+    await UploadSummaryLogPage.continue()
+
+    await checkBodyText('Your file is being checked', 30)
+    await checkBodyText('Check before confirming upload', 60)
+    expect(
+      await UploadSummaryLogPage.confirmAndSubmitPreventsDoubleClick()
+    ).toBe('true')
+
+    const url = await browser.getUrl()
+    const [, orgId, regId, summaryLogId] = url.match(
+      /organisations\/([^/]+)\/registrations\/([^/]+)\/summary-logs\/([^/?#]+)/
+    )
+
+    // Pre-submit via backend API — bypasses the browser session guard and
+    // puts the log into SUBMITTING before the browser POSTs, guaranteeing a 409
+    const authClient = new AuthClient()
+    await authClient.authenticate()
+    const eprBackend = new EprBackend()
+    await eprBackend.post(
+      `/v1/organisations/${orgId}/registrations/${regId}/summary-logs/${summaryLogId}/submit`,
+      '',
+      authClient.authHeader()
+    )
+
+    await UploadSummaryLogPage.confirmAndSubmit()
+
+    await checkBodyText('Your waste records cannot be updated', 10)
+    await checkBodyTextDoesNotInclude('Your waste records are being updated', 5)
 
     await HomePage.signOut()
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
## Description

Adds journey test coverage for double-click prevention on summary log action buttons

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).
