### PR TITLE
PAE-250: Fix protobufjs and ws vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8887,9 +8887,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -11312,9 +11312,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -52,9 +52,10 @@
     "undici": "7.24.5"
   },
   "overrides": {
-    "protobufjs": "7.5.6",
+    "protobufjs": "7.5.8",
     "serialize-javascript": "7.0.5",
-    "uuid": "14.0.0"
+    "uuid": "14.0.0",
+    "ws": "8.20.1"
   },
   "devDependencies": {
     "eslint": "9.39.4",


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Fixes two medium-severity transitive dependency vulnerabilities flagged by Snyk:

- **protobufjs** (SNYK-JS-PROTOBUFJS-16657755, Uncontrolled Recursion): bumps
  the existing override from 7.5.6 to 7.5.8, which contains the fix. Pulled in
  transitively via `@wdio/browserstack-service > @grpc/grpc-js > @grpc/proto-loader`.

- **ws** (SNYK-JS-WS-16722635, Use of Uninitialised Resource): adds a new
  override pinning ws to 8.20.1, which contains the fix. Pulled in transitively
  via `@wdio/browserstack-service > webdriverio > webdriver`.

Both are transitive dependencies whose parent packages have not yet updated
their dependency ranges, so overrides are the appropriate fix.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ