### PR TITLE
PAE-1482: add submit page guard journey test

### DIFF
--- a/test/specs/registered.exporter.report.e2e.js
+++ b/test/specs/registered.exporter.report.e2e.js
@@ -234,6 +234,33 @@ describe('Registered-only exporter report flow @registeredOnlyExporter', () => {
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
   })
 
+  it('should redirect to submitted confirmation page when navigating back to submit after submission @registeredOnlyExporterSubmitGuard', async () => {
+    await setupRegisteredOnlyExporter()
+    await uploadAndNavigateToReports()
+
+    // Complete the full flow through to submission
+    await ReportsPage.selectActionLink(1)
+    await ReportDetailPage.useThisData()
+    await TonnesNotExportedPage.enterTonnage('5.50')
+    await TonnesNotExportedPage.continue()
+    await ReportSupportingInformationPage.continue()
+    await ReportCheckAnswersPage.createReport()
+    await checkBodyText('report created', 30)
+    await ConfirmationPage.goToReports()
+    await ReportsPage.selectActionLink(1)
+    await MonthlyReportDraftDeclarationPage.confirmAndSubmit()
+    await checkBodyText('report submitted to regulator', 30)
+
+    // Navigate back to the submit page — the guard should redirect back to submitted
+    await browser.back()
+
+    const confirmationText = await ReportSubmittedPage.confirmationText()
+    expect(confirmationText).toContain('report submitted to regulator')
+
+    await HomePage.signOut()
+    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+  })
+
   it('should navigate back correctly through the registered-only exporter flow @registeredOnlyExporterBackLinks', async () => {
     await setupRegisteredOnlyExporter()
     await uploadAndNavigateToReports()


### PR DESCRIPTION
Ticket: [PAE-1482](https://eaflood.atlassian.net/browse/PAE-1482)
## Description

Adds journey test @registeredOnlyExporterSubmitGuard to verify that navigating back to the report submit page after submission redirects to the confirmation page rather than re-rendering the form

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1482]: https://eaflood.atlassian.net/browse/PAE-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ