### PR TITLE
PAE-250: Fix brace-expansion vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1870,9 +1870,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2077,9 +2077,9 @@
       }
     },
     "node_modules/@wdio/browserstack-service/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -52,10 +52,8 @@
     "undici": "7.24.5"
   },
   "overrides": {
-    "protobufjs": "7.5.8",
     "serialize-javascript": "7.0.5",
-    "uuid": "14.0.0",
-    "ws": "8.20.1"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "eslint": "9.39.4",


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)

## Summary

Resolves the `brace-expansion` DoS vulnerability
([GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2))
by updating lockfile resolutions from 5.0.5 to 5.0.6.

`brace-expansion` versions 5.0.2 through 5.0.5 allow large numeric ranges to
bypass the documented `max` parameter, enabling excessive memory and CPU usage.
Version 5.0.6 fixes this.

Also removes two stale overrides that are no longer needed:
- `protobufjs` (parent dependency now resolves a non-vulnerable version)
- `ws` (parent dependency now resolves a non-vulnerable version)

Remaining overrides (`serialize-javascript`, `uuid`) and the `.snyk` ignore
for `SNYK-JS-INFLIGHT-6095116` were tested and confirmed still required.

Verified clean against both `npm audit` and `snyk test` after all changes.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ