### PR TITLE
PAE-250: Fix tmp path traversal vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10559,9 +10559,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "overrides": {
     "serialize-javascript": "7.0.5",
+    "tmp": "0.2.6",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## What changed

Pins `tmp` to its patched version `0.2.6` via an npm `override`. This fixes a path traversal where an unsanitised prefix/postfix could escape the intended temp directory (high, GHSA-ph9p-34f9-6g65). `tmp` reaches us transitively through `@wdio/browserstack-service` → `@percy/appium-app`. There are no test code changes.

## Note on `tmp` 0.2.6

This repo's `.npmrc` sets `min-release-age=7`, a quarantine that keeps freshly published packages out of dependency resolution for seven days. `tmp` 0.2.6 is the only release that fixes the path-traversal advisory and it is newer than that window, so it is pinned here as a deliberate exception rather than leaving the high-severity hole open. The published 0.2.5 → 0.2.6 diff was reviewed before adopting it: the only change is the security fix (a new check that rejects `..` in prefix/postfix/template, plus a corrected directory-containment test), it adds no new dependencies and no install scripts, and it comes from the package's long-standing maintainer. `npm ci` installs the lockfile-pinned version irrespective of the age policy, so CI is unaffected.

## Existing policy entries

The existing `serialize-javascript` and `uuid` overrides and the `SNYK-JS-INFLIGHT-6095116` Snyk ignore were each re-checked by removing them and re-testing. All three still suppress live advisories — `mocha` pulling a vulnerable `serialize-javascript`, `@browserstack/ai-sdk-node` pulling a vulnerable `uuid`, and `inflight` reached through the mocha/glob chain — so all are retained unchanged.


[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ