### PR TITLE
PAE-1538: clarify invalid-date cell error with dd/mm/yyyy format

### DIFF
--- a/test/specs/summarylogs.unhappy.paths.e2e.js
+++ b/test/specs/summarylogs.unhappy.paths.e2e.js
@@ -188,7 +188,7 @@ describe('Summary Logs - Unhappy paths @unhappyPaths', () => {
         columnHeader: 'Date received for export',
         cell: 'G4',
         dataEntered: '????',
-        errorMessage: 'Must be a valid date'
+        errorMessage: 'Must be a valid date in the format dd/mm/yyyy'
       },
       {
         rowId: '',
@@ -292,7 +292,7 @@ describe('Summary Logs - Unhappy paths @unhappyPaths', () => {
         columnHeader: 'Date of export',
         cell: 'U4',
         dataEntered: 'TBC',
-        errorMessage: 'Must be a valid date'
+        errorMessage: 'Must be a valid date in the format dd/mm/yyyy'
       },
       {
         rowId: '',
@@ -358,7 +358,7 @@ describe('Summary Logs - Unhappy paths @unhappyPaths', () => {
         columnHeader: 'Date load left site',
         cell: 'G4',
         dataEntered: '???',
-        errorMessage: 'Must be a valid date'
+        errorMessage: 'Must be a valid date in the format dd/mm/yyyy'
       },
       {
         rowId: '',


### PR DESCRIPTION
Ticket: [PAE-1538](https://eaflood.atlassian.net/browse/PAE-1538)

amends the summary-log invalid-date cell error message.

- `DATE_FORMAT_INVALID` cell reason now reads "Must be a valid date in the format dd/mm/yyyy"


[PAE-1538]: https://eaflood.atlassian.net/browse/PAE-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ