### PR TITLE
PAE-1544: node/npm toolchain tune-up

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
-      - run: npm install -g npm@11.12.1
       - run: |
           npm ci --ignore-scripts
           npm run format:check
@@ -53,7 +52,6 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
-      - run: npm install -g npm@11.12.1
       - run: |
           npm ci --ignore-scripts
           npm run lint:types

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
 gitleaks = "8.30.0"
+node = "24.15.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,7 @@
         "typescript": "5.9.3"
       },
       "engines": {
-        "node": ">=24.15.0 <25",
-        "npm": ">=11.11.0"
+        "node": ">=24.15.0 <25"
       }
     },
     "node_modules/@axe-core/webdriverio": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "type": "module",
   "description": "",
   "engines": {
-    "node": ">=24.15.0 <25",
-    "npm": ">=11.11.0"
+    "node": ">=24.15.0 <25"
   },
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>DEFRA/epr-re-ex-service//renovate-presets/default"],
-  "enabledManagers": ["dockerfile", "docker-compose", "nvm", "custom.regex"]
+  "enabledManagers": [
+    "dockerfile",
+    "docker-compose",
+    "nvm",
+    "custom.regex",
+    "mise"
+  ]
 }


### PR DESCRIPTION
Ticket: [PAE-1544](https://eaflood.atlassian.net/browse/PAE-1544)
- pin node in mise + enable renovate mise manager
- drop redundant engines.npm + ci npm-upgrade step

[PAE-1544]: https://eaflood.atlassian.net/browse/PAE-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ