### PR TITLE
PAE-250: Remove stale axios override

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "undici": "7.24.5"
   },
   "overrides": {
-    "axios": "1.16.1",
     "serialize-javascript": "7.0.5",
     "uuid": "14.0.0"
   },


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
The `axios` override that pinned version `1.16.1` is no longer doing any work. The dependency tree now resolves axios to `1.16.1` on its own without the override forcing it, so the pin is redundant and only adds noise to the `overrides` block.

Removing it leaves the resolved tree unchanged — `package-lock.json` is byte-identical and axios stays at `1.16.1` — and both npm audit and Snyk continue to report zero vulnerabilities. The remaining `serialize-javascript` and `uuid` overrides were tested the same way and are still required (they hold back transitive dependencies that would otherwise resolve to vulnerable versions), so they stay.

This is routine pruning of the override list to keep it reflecting only the pins that are actually load-bearing.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ