### PR TITLE
PAE-250: Fix grpc-js and tmp vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "typescript": "5.9.3"
       },
       "engines": {
-        "node": ">=24.15.0 <25"
+        "node": ">=24.16.0 <25"
       }
     },
     "node_modules/@axe-core/webdriverio": {
@@ -676,9 +676,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.3.tgz",
-      "integrity": "sha512-FTXHdOoPbZrBjlVLHuKbDZnsTxXv2BlHF57xw6LuThXacXvtkahEPED0CKMk6obZDf65Hv4k3z62eyPNpvinIg==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.5.tgz",
+      "integrity": "sha512-ILtqflBY9tzd79bKa87eS98vZFCso5/uYxuArfcKrmRDatRg7KWmI/Vr9+xOEf2Y2E/44HXMCx3JKZe/Y4yF6g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
@@ -10648,9 +10648,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "undici": "7.24.5"
   },
   "overrides": {
+    "@grpc/grpc-js": "1.13.5",
     "serialize-javascript": "7.0.5",
+    "tmp": "0.2.7",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
Fixes two high-severity vulnerabilities flagged by Snyk in the test tooling.

- Pins `@grpc/grpc-js` to 1.13.5 via an override, clearing SNYK-JS-GRPCGRPCJS-17315646 and -17315972 (uncaught exception leading to a crash). It is pulled in through `@wdio/browserstack-service`. An override is used rather than `npm audit fix --force`, which would downgrade `@wdio/browserstack-service`.
- Pins `tmp` to 0.2.7 via an override, clearing SNYK-JS-TMP-17315641 (directory traversal), pulled in through `@percy/appium-app`.

Existing `serialize-javascript` and `uuid` overrides and the `SNYK-JS-INFLIGHT-6095116` ignore were checked and confirmed still needed. After the change `snyk test` finds no vulnerable paths and `npm audit` reports no vulnerabilities.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ