### PR TITLE
PAE-1567: Pin auth stub images to fixed versions

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -134,7 +134,7 @@ services:
         condition: service_completed_successfully
 
   defra-id-stub:
-    image: defradigital/cdp-defra-id-stub:${DEFRA_ID_STUB_VERSION:-latest}
+    image: defradigital/cdp-defra-id-stub:0.34.0
     ports:
       - '3200:3200'
     depends_on:
@@ -153,7 +153,7 @@ services:
       USE_SINGLE_INSTANCE_CACHE: true
 
   epr-re-ex-entra-stub:
-    image: defradigital/epr-re-ex-entra-stub:latest
+    image: defradigital/epr-re-ex-entra-stub:0.66.0
     ports:
       - 3010:3010
     environment:


### PR DESCRIPTION
Ticket: [PAE-1567](https://eaflood.atlassian.net/browse/PAE-1567)
The journey-test `compose.yml` floated both auth stub images: `cdp-defra-id-stub` via a `${DEFRA_ID_STUB_VERSION:-latest}` override variable, and `epr-re-ex-entra-stub` on `:latest`. On 2026-06-15 the `cdp-defra-id-stub:latest` tag was republished as 0.35.0, which broke the Defra ID org-linking auth flow and turned the journey suite red (org-linking setup step 500), blocking in-flight PRs.

This pins `cdp-defra-id-stub` to 0.34.0 (the last-good version before 0.35.0) and `epr-re-ex-entra-stub` to its current published version 0.66.0, and drops the bespoke `${DEFRA_ID_STUB_VERSION:-latest}` override variable. With the floating tags gone, Renovate's already-enabled `docker-compose` manager will track the pinned tags and raise version bumps like every other dependency, so the next stub upgrade lands as a reviewable PR with its own journey-test run rather than silently breaking on a `latest` republish.

[PAE-1567]: https://eaflood.atlassian.net/browse/PAE-1567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ