### PR TITLE
Pin node version to 24.16 because of webdriver limitation with Undici 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "",
   "engines": {
-    "node": ">=24.16.0 <25"
+    "node": "<=24.16.0"
   },
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",

--- a/renovate.json
+++ b/renovate.json
@@ -7,14 +7,5 @@
     "nvm",
     "custom.regex",
     "mise"
-  ],
-  "packageRules": [
-    {
-      "matchManagers": ["nvm", "node-version"],
-      "matchDepNames": ["node"],
-      "allowedVersions": "<=24.16.x",
-      "enabled": true,
-      "description": "Pinned: Node 24.17+ bundles stricter undici fetch validation that rejects webdriver's manual Content-Length/Connection headers (UND_ERR_INVALID_ARG). Unpin once webdriverio/webdriver ships a fix."
-    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,14 @@
     "nvm",
     "custom.regex",
     "mise"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["nvm", "node-version"],
+      "matchDepNames": ["node"],
+      "allowedVersions": "<=24.16.x",
+      "enabled": true,
+      "description": "Pinned: Node 24.17+ bundles stricter undici fetch validation that rejects webdriver's manual Content-Length/Connection headers (UND_ERR_INVALID_ARG). Unpin once webdriverio/webdriver ships a fix."
+    }
   ]
 }


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
Node 24.17+ bundles stricter undici fetch validation that rejects webdriver's manual Content-Length/Connection headers (UND_ERR_INVALID_ARG). This means once we start using Node 24.17+, webdriver smoke tests will start failing in the CDP Portal as the Dockerfile builds Node before executing the tests. Pin the version until webdriver fixes this or we move away from webdriver.