### PR TITLE
PAE-1339: make jsconfig ts 6.0 ready

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "baseUrl": "./",
+    "types": ["node", "mocha", "@wdio/globals/types", "expect-webdriverio"],
     "paths": {
       "~/*": ["./*"],
       "page-objects/*": ["./test/page-objects/*"],

--- a/jsconfig.typecheck.json
+++ b/jsconfig.typecheck.json
@@ -16,7 +16,7 @@
     "strictNullChecks": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "baseUrl": ".",
+    "types": ["node", "mocha", "@wdio/globals/types", "expect-webdriverio"],
     "paths": {
       "~/*": ["./*"],
       "page-objects/*": ["./test/page-objects/*"],


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
prep typecheck configs for the typescript 6.0 bump so dependabot lands cleanly.

- drop deprecated `baseUrl` (paths resolve relative to the config since ts 5.0)
- add explicit `types` array for the wdio/mocha globals, which ts 6.0 no longer auto-includes from transitive @types

verified `lint:types` clean on both 5.9.3 and 6.0.3.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ