### PR TITLE
PAE-000: pin node patch and unpin alpine minor in base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.17-alpine3.24
+FROM node:24.17.0-alpine
 
 ENV TZ="Europe/London"
 

--- a/docker/mock/Dockerfile
+++ b/docker/mock/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0-alpine3.22
+FROM node:24.15.0-alpine
 WORKDIR /app
 RUN npm init -y && npm install express
 COPY ./docker/mock/waste.organisations.js .


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
pin the node patch and stop pinning the alpine minor in the node base images:
- `Dockerfile`: `node:24.17-alpine3.24` -> `node:24.17.0-alpine`
- `docker/mock/Dockerfile`: `node:24.15.0-alpine3.22` -> `node:24.15.0-alpine`

pinning the alpine minor coupled node-patch availability to a specific alpine release (node 24.17 ships only on alpine 3.23/3.24), blocking renovate updates and breaking docker builds. pinning the node patch keeps the version explicit. pairs with digest pinning (epr-re-ex-service#290) so the exact image is locked and every change is a reviewable renovate PR.