### PR TITLE
PAE-000: bump mock base image to node 24.17.0

### DIFF
--- a/docker/mock/Dockerfile
+++ b/docker/mock/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0-alpine
+FROM node:24.17.0-alpine
 WORKDIR /app
 RUN npm init -y && npm install express
 COPY ./docker/mock/waste.organisations.js .


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
bring the mock service base image up to date: `node:24.15.0-alpine` -> `node:24.17.0-alpine`. it had been frozen at 24.15.0 (68+ days) because the previous `-alpine3.22` pin variant-locked it (node 24.16/24.17 are not published for alpine3.22), so renovate offered no updates. now that alpine is unpinned, renovate will keep it current going forward.