### PR TITLE
PAE-1331: introduce overdue report status in the ui

### DIFF
--- a/test/specs/accredited.exporter.report.e2e.js
+++ b/test/specs/accredited.exporter.report.e2e.js
@@ -25,6 +25,7 @@ import {
   switchToNewTab,
   closeCurrentTabAndReturn
 } from '../support/windowtabs.js'
+import { expectActionRequiredStatus } from '../support/report-status.js'
 import MonthlyReportDraftDeclarationPage from 'page-objects/reports/monthly.report.draft.declaration.page.js'
 import ReportSubmittedPage from 'page-objects/reports/report.submitted.page.js'
 
@@ -145,11 +146,7 @@ describe('Accredited exporter report flow @accreditedExporter', () => {
       let reportsHeading = await ReportsPage.headingText()
       expect(reportsHeading).toContain('Reports')
 
-      let statusBadge = await ReportsPage.getActiveStatusBadge(1)
-      let statusColour = await ReportsPage.getActiveStatusColour(1)
-
-      expect(statusBadge).toBe('Due')
-      expect(statusColour).toBe('orange')
+      await expectActionRequiredStatus(1)
 
       // --- Create report again, navigate to free-perns, delete from there ---
       await ReportsPage.selectActiveActionLink(1)
@@ -168,11 +165,7 @@ describe('Accredited exporter report flow @accreditedExporter', () => {
       reportsHeading = await ReportsPage.headingText()
       expect(reportsHeading).toContain('Reports')
 
-      statusBadge = await ReportsPage.getActiveStatusBadge(1)
-      statusColour = await ReportsPage.getActiveStatusColour(1)
-
-      expect(statusBadge).toBe('Due')
-      expect(statusColour).toBe('orange')
+      await expectActionRequiredStatus(1)
     })
 
     it('should save and come back later from PRN summary and free PERNs pages @accreditedExporterSave', async () => {

--- a/test/specs/accredited.reprocessor.report.e2e.js
+++ b/test/specs/accredited.reprocessor.report.e2e.js
@@ -26,6 +26,7 @@ import {
   switchToNewTab,
   closeCurrentTabAndReturn
 } from '../support/windowtabs.js'
+import { expectActionRequiredStatus } from '../support/report-status.js'
 import MonthlyReportDraftDeclarationPage from 'page-objects/reports/monthly.report.draft.declaration.page.js'
 import ReportSubmittedPage from 'page-objects/reports/report.submitted.page.js'
 
@@ -173,11 +174,7 @@ describe('Accredited reprocessor report flow @accreditedReprocessor', () => {
       let reportsHeading = await ReportsPage.headingText()
       expect(reportsHeading).toContain('Reports')
 
-      let statusBadge = await ReportsPage.getActiveStatusBadge(1)
-      let statusColour = await ReportsPage.getActiveStatusColour(1)
-
-      expect(statusBadge).toBe('Due')
-      expect(statusColour).toBe('orange')
+      await expectActionRequiredStatus(1)
 
       // --- Create report again, navigate to prn-summary, delete from there ---
       await ReportsPage.selectActiveActionLink(1)
@@ -198,11 +195,7 @@ describe('Accredited reprocessor report flow @accreditedReprocessor', () => {
       reportsHeading = await ReportsPage.headingText()
       expect(reportsHeading).toContain('Reports')
 
-      statusBadge = await ReportsPage.getActiveStatusBadge(1)
-      statusColour = await ReportsPage.getActiveStatusColour(1)
-
-      expect(statusBadge).toBe('Due')
-      expect(statusColour).toBe('orange')
+      await expectActionRequiredStatus(1)
     })
 
     it('should save and come back later from tonnes recycled page @accreditedReprocessorSave', async () => {

--- a/test/specs/delete.ready.to.submit.report.e2e.js
+++ b/test/specs/delete.ready.to.submit.report.e2e.js
@@ -21,6 +21,7 @@ import {
   linkDefraIdUser,
   updateMigratedOrganisation
 } from '../support/apicalls.js'
+import { expectActionRequiredStatus } from '../support/report-status.js'
 
 async function navigateReprocessorToSupportingInfo() {
   await TonnesRecycledPage.enterTonnage('10')
@@ -118,11 +119,7 @@ describe('Deleting a ready to submit report', () => {
     const reportsHeading = await ReportsPage.headingText()
     expect(reportsHeading).toContain('Reports')
 
-    const statusBadge = await ReportsPage.getActiveStatusBadge(1)
-    const statusColour = await ReportsPage.getActiveStatusColour(1)
-
-    expect(statusBadge).toBe('Due')
-    expect(statusColour).toBe('orange')
+    await expectActionRequiredStatus(1)
 
     await HomePage.signOut()
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))

--- a/test/specs/delete.report.e2e.js
+++ b/test/specs/delete.report.e2e.js
@@ -19,6 +19,7 @@ import {
   linkDefraIdUser,
   updateMigratedOrganisation
 } from '../support/apicalls.js'
+import { expectActionRequiredStatus } from '../support/report-status.js'
 
 async function navigateReprocessorToSupportingInfo() {
   await TonnesRecycledPage.enterTonnage('10')
@@ -115,11 +116,7 @@ describe('Deleting an in-progress report', () => {
     let reportsHeading = await ReportsPage.headingText()
     expect(reportsHeading).toContain('Reports')
 
-    let statusBadge = await ReportsPage.getActiveStatusBadge(1)
-    let statusColour = await ReportsPage.getActiveStatusColour(1)
-
-    expect(statusBadge).toBe('Due')
-    expect(statusColour).toBe('orange')
+    await expectActionRequiredStatus(1)
 
     // --- Delete from check your answers page ---
 
@@ -156,11 +153,7 @@ describe('Deleting an in-progress report', () => {
     reportsHeading = await ReportsPage.headingText()
     expect(reportsHeading).toContain('Reports')
 
-    statusBadge = await ReportsPage.getActiveStatusBadge(1)
-    statusColour = await ReportsPage.getActiveStatusColour(1)
-
-    expect(statusBadge).toBe('Due')
-    expect(statusColour).toBe('orange')
+    await expectActionRequiredStatus(1)
 
     await HomePage.signOut()
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))

--- a/test/specs/stale.summary.log.report.e2e.js
+++ b/test/specs/stale.summary.log.report.e2e.js
@@ -21,6 +21,7 @@ import {
   updateMigratedOrganisation
 } from '../support/apicalls.js'
 import seedOverseasSites from '~/test/support/apicalls.js'
+import { expectActionRequiredStatus } from '../support/report-status.js'
 
 const PL_REG = 'R25SR500010912PL'
 const PL_ACC = 'R-ACC12145PL'
@@ -148,11 +149,11 @@ describe('Stale summary log report @staleReport', () => {
       'Your summary log has changed'
     )
 
-    // "Delete and start again" deletes the report and returns to reports with status Due
+    // "Delete and start again" deletes the report and returns to reports with
+    // its un-started action-required status (Due, or Overdue if past due date)
     await SummaryLogChangedErrorPage.deleteAndStartAgain()
     expect(await ReportsPage.headingText()).toContain('Reports')
-    expect(await ReportsPage.getActiveStatusBadge(1)).toBe('Due')
-    expect(await ReportsPage.getActiveStatusColour(1)).toBe('orange')
+    await expectActionRequiredStatus(1)
 
     await HomePage.signOut()
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
@@ -189,11 +190,11 @@ describe('Stale summary log report @staleReport', () => {
       'Your summary log has changed'
     )
 
-    // "Delete and start again" deletes the report and returns to reports with status Due
+    // "Delete and start again" deletes the report and returns to reports with
+    // its un-started action-required status (Due, or Overdue if past due date)
     await SummaryLogChangedErrorPage.deleteAndStartAgain()
     expect(await ReportsPage.headingText()).toContain('Reports')
-    expect(await ReportsPage.getActiveStatusBadge(1)).toBe('Due')
-    expect(await ReportsPage.getActiveStatusColour(1)).toBe('orange')
+    await expectActionRequiredStatus(1)
 
     await HomePage.signOut()
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))

--- a/test/support/report-status.js
+++ b/test/support/report-status.js
@@ -1,0 +1,22 @@
+import { expect } from '@wdio/globals'
+import ReportsPage from 'page-objects/reports/reports.page.js'
+
+const ACTION_REQUIRED_COLOUR = { Due: 'orange', Overdue: 'red' }
+
+/**
+ * Assert an active reports row shows an "action required" status for an
+ * un-started period: Due (orange) or Overdue (red).
+ *
+ * A period flips from Due to Overdue at 00:00 on the 21st of the month following
+ * the reporting period (once its due date has passed). The suite runs against a
+ * remote environment whose clock we cannot control, so we accept either status
+ * rather than asserting a time-dependent value.
+ * @param {number} rowIndex
+ */
+export const expectActionRequiredStatus = async (rowIndex) => {
+  const badge = await ReportsPage.getActiveStatusBadge(rowIndex)
+  const colour = await ReportsPage.getActiveStatusColour(rowIndex)
+
+  expect(Object.keys(ACTION_REQUIRED_COLOUR)).toContain(badge)
+  expect(colour).toBe(ACTION_REQUIRED_COLOUR[badge])
+}


### PR DESCRIPTION
Ticket: [PAE-1331](https://eaflood.atlassian.net/browse/PAE-1331)

adds an overdue report status to the reports list.

- a report shows overdue (red tag) once the current date is past its due date (the 20th of the month after the reporting period), replacing the due tag
- date due is unchanged; overdue still transitions through the normal flow
- frontend-only: due/overdue are derived display states, not persisted
- journey specs now tolerate due or overdue, as the suite runs against a remote env whose clock we cannot control

[PAE-1331]: https://eaflood.atlassian.net/browse/PAE-1331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ