### PR TITLE
PAE-1541: Enable enhanced check page in journey tests

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -235,6 +235,7 @@ services:
       DEFRA_ID_OIDC_CONFIGURATION_URL: http://defra-id-stub:3200/cdp-defra-id-stub/.well-known/openid-configuration
       DEFRA_ID_SERVICE_ID: d7d72b79-9c62-ee11-8df0-000d3adf7047
       EPR_BACKEND_URL: http://epr-backend:3001
+      FEATURE_FLAG_ENHANCED_SUMMARY_LOG_CHECK_PAGES: true
       NODE_ENV: development
       PORT: 3000
       REDIS_HOST: redis

--- a/test/page-objects/enhanced.check.summary.log.page.js
+++ b/test/page-objects/enhanced.check.summary.log.page.js
@@ -27,7 +27,7 @@ class EnhancedCheckSummaryLogPage {
   }
 
   async upload() {
-    await $('button[type="submit"]').click()
+    await $('#main-content button[type=submit]').click()
   }
 }
 

--- a/test/page-objects/upload.summary.log.page.js
+++ b/test/page-objects/upload.summary.log.page.js
@@ -77,10 +77,6 @@ class UploadSummaryLogPage extends SummaryLogUploadActions {
     })
   }
 
-  async confirmAndSubmit() {
-    await $('#main-content button[type=submit]').click()
-  }
-
   async returnToSubmissionPage() {
     await $('#main-content form > div.govuk-button-group > a').click()
   }

--- a/test/page-objects/upload.summary.log.page.js
+++ b/test/page-objects/upload.summary.log.page.js
@@ -1,8 +1,5 @@
 import { browser, $, $$ } from '@wdio/globals'
-import {
-  checkBodyText,
-  checkBodyTextDoesNotInclude
-} from '../support/checks.js'
+import { checkBodyText } from '../support/checks.js'
 import { SummaryLogUploadActions } from './summary-log-upload-actions.js'
 import EnhancedCheckSummaryLogPage from './enhanced.check.summary.log.page.js'
 
@@ -13,24 +10,9 @@ class UploadSummaryLogPage extends SummaryLogUploadActions {
     return await element.getText()
   }
 
-  // TODO: flag switchover - replaced by performUploadAndReturnToHomepageEnhanced below.
+  // The enhanced (CMA) upload flow, now the only check page after the
+  // FEATURE_FLAG_ENHANCED_SUMMARY_LOG_CHECK_PAGES switchover.
   async performUploadAndReturnToHomepage(filePath) {
-    await this.uploadFile(filePath)
-    await this.continue()
-
-    await checkBodyText('Your summary log is being checked', 30)
-    await checkBodyText('Check before confirming upload', 60)
-    await this.confirmAndSubmit()
-
-    await checkBodyText('Your waste records are being updated', 30)
-    await checkBodyTextDoesNotInclude('Declaration', 10)
-    await checkBodyText('Summary log uploaded', 60)
-    await this.clickOnReturnToHomePage()
-  }
-
-  // The enhanced (CMA) upload flow. Kept live (not commented) so it can't drift;
-  // used by the CMA spec now, becomes performUploadAndReturnToHomepage at switchover.
-  async performUploadAndReturnToHomepageEnhanced(filePath) {
     await this.uploadFile(filePath)
     await this.continue()
 

--- a/test/specs/summarylogs.enhanced.check.cma.e2e.js
+++ b/test/specs/summarylogs.enhanced.check.cma.e2e.js
@@ -23,8 +23,7 @@ import {
 const ADJUSTED_ACCORDION_MSG =
   /(has|have) all the required summary log data and (has|have) (added to|reduced) your waste balance|(does|do) NOT have all the required summary log data and (has|have) reduced your waste balance/
 
-// TODO: flag switchover - remove .skip
-describe.skip('Summary Logs - Enhanced Check Page with CMA Detection', () => {
+describe('Summary Logs - Enhanced Check Page with CMA Detection', () => {
   // Resets the shared browser session between tests. Without it, leftover auth
   // state makes a later "start now" auto-log-in and skip the stub's user-selection
   // page, so loginViaEmail times out (passes solo, fails in suite). deleteCookies
@@ -150,7 +149,7 @@ describe.skip('Summary Logs - Enhanced Check Page with CMA Detection', () => {
     expect(regNo).toExist()
 
     await WasteRecordsPage.submitSummaryLogLink()
-    await UploadSummaryLogPage.performUploadAndReturnToHomepageEnhanced(
+    await UploadSummaryLogPage.performUploadAndReturnToHomepage(
       'resources/reprocessor-output.xlsx'
     )
 
@@ -291,7 +290,7 @@ describe.skip('Summary Logs - Enhanced Check Page with CMA Detection', () => {
     await DashboardPage.selectLink(1)
 
     await WasteRecordsPage.submitSummaryLogLink()
-    await UploadSummaryLogPage.performUploadAndReturnToHomepageEnhanced(
+    await UploadSummaryLogPage.performUploadAndReturnToHomepage(
       'resources/exporter.xlsx'
     )
 
@@ -430,7 +429,7 @@ describe.skip('Summary Logs - Enhanced Check Page with CMA Detection', () => {
     await DashboardPage.selectLink(1)
 
     await WasteRecordsPage.submitSummaryLogLink()
-    await UploadSummaryLogPage.performUploadAndReturnToHomepageEnhanced(
+    await UploadSummaryLogPage.performUploadAndReturnToHomepage(
       'resources/exporter.xlsx'
     )
 
@@ -538,7 +537,7 @@ describe.skip('Summary Logs - Enhanced Check Page with CMA Detection', () => {
     await DashboardPage.selectLink(1)
 
     await WasteRecordsPage.submitSummaryLogLink()
-    await UploadSummaryLogPage.performUploadAndReturnToHomepageEnhanced(
+    await UploadSummaryLogPage.performUploadAndReturnToHomepage(
       'resources/reprocessor-output-regonly.xlsx'
     )
 
@@ -681,7 +680,7 @@ describe.skip('Summary Logs - Enhanced Check Page with CMA Detection', () => {
     await DashboardPage.selectLink(1)
 
     await WasteRecordsPage.submitSummaryLogLink()
-    await UploadSummaryLogPage.performUploadAndReturnToHomepageEnhanced(
+    await UploadSummaryLogPage.performUploadAndReturnToHomepage(
       'resources/exporter-2025.xlsx'
     )
 

--- a/test/specs/summarylogs.exporter.e2e.js
+++ b/test/specs/summarylogs.exporter.e2e.js
@@ -2,6 +2,7 @@ import { $, browser, expect } from '@wdio/globals'
 import DefraIdStubPage from 'page-objects/defra.id.stub.page.js'
 import HomePage from 'page-objects/homepage.js'
 import UploadSummaryLogPage from '../page-objects/upload.summary.log.page.js'
+import EnhancedCheckSummaryLogPage from '../page-objects/enhanced.check.summary.log.page.js'
 import WasteRecordsPage from '../page-objects/waste.records.page.js'
 import DashboardPage from '../page-objects/dashboard.page.js'
 import { checkBodyText } from '../support/checks.js'
@@ -72,15 +73,13 @@ describe('Summary Logs Exporter', () => {
     await UploadSummaryLogPage.continue()
 
     await checkBodyText('Your summary log is being checked', 30)
-    // TODO: flag switchover - remove the legacy check-page assertions below
-    await checkBodyText('Check before confirming upload', 60)
-    await checkBodyText('2 new loads will be added to your waste balance', 10)
-    await UploadSummaryLogPage.confirmAndSubmit()
-    // TODO: flag switchover - uncomment the enhanced check-page assertions below (and import EnhancedCheckSummaryLogPage)
-    // await checkBodyText('Upload your summary log', 60)
-    // await checkBodyText('Open periods: new loads', 30)
-    // await checkBodyText('2 new loads will be recorded (and will add to your waste balance)', 30)
-    // await EnhancedCheckSummaryLogPage.upload()
+    await checkBodyText('Upload your summary log', 60)
+    await checkBodyText('Open periods: new loads', 30)
+    await checkBodyText(
+      '2 new loads will be recorded (and will add to your waste balance)',
+      30
+    )
+    await EnhancedCheckSummaryLogPage.upload()
 
     await checkBodyText('Your waste records are being updated', 30)
 
@@ -106,22 +105,18 @@ describe('Summary Logs Exporter', () => {
     await UploadSummaryLogPage.continue()
 
     await checkBodyText('Your summary log is being checked', 30)
-    // TODO: flag switchover - remove the legacy check-page assertions below
-    await checkBodyText('Check before confirming upload', 60)
-    await checkBodyText('3 new loads will be added to your waste balance', 10)
+    await checkBodyText('Upload your summary log', 60)
+    await checkBodyText('Open periods: new loads', 30)
     await checkBodyText(
-      '2 adjusted loads will be reflected in your waste balance',
-      10
+      '3 new loads will be recorded (and will add to your waste balance)',
+      30
     )
-
-    await UploadSummaryLogPage.confirmAndSubmit()
-    // TODO: flag switchover - uncomment the enhanced check-page assertions below (and import EnhancedCheckSummaryLogPage)
-    // await checkBodyText('Upload your summary log', 60)
-    // await checkBodyText('Open periods: new loads', 30)
-    // await checkBodyText('3 new loads will be recorded (and will add to your waste balance)', 30)
-    // await checkBodyText('Open periods: adjusted loads', 30)
-    // await checkBodyText('1 adjusted load will be recorded (and will reflect in your waste balance)', 30)
-    // await EnhancedCheckSummaryLogPage.upload()
+    await checkBodyText('Open periods: adjusted loads', 30)
+    await checkBodyText(
+      '1 adjusted load will be recorded (and will reflect in your waste balance)',
+      30
+    )
+    await EnhancedCheckSummaryLogPage.upload()
 
     await checkBodyText('Your waste records are being updated', 30)
 

--- a/test/specs/summarylogs.registered.only.e2e.js
+++ b/test/specs/summarylogs.registered.only.e2e.js
@@ -14,6 +14,7 @@ import {
   checkBodyTextDoesNotInclude
 } from '../support/checks.js'
 import UploadSummaryLogPage from 'page-objects/upload.summary.log.page.js'
+import EnhancedCheckSummaryLogPage from 'page-objects/enhanced.check.summary.log.page.js'
 
 describe('@registered-only', () => {
   it('should be able to upload Registered Only Reprocessor Summary Logs for registered-only operators and display unaccredited registrations alongside accredited ones @regOnlyReprocessor', async () => {
@@ -108,20 +109,11 @@ describe('@registered-only', () => {
 
     await checkBodyText('Your summary log is being checked', 30)
 
-    // TODO: flag switchover - remove the legacy check-page assertions below
-    //   (the 'Loads received/sent on' breakdown has no enhanced equivalent)
-    await checkBodyText('Check before confirming upload', 30)
-    await checkBodyText('Check the following before confirming the upload.', 30)
-    await checkBodyText('Loads received', 30)
-    await checkBodyText('Loads sent on', 30)
-    await checkBodyText('new loads have been added', 30)
-    await UploadSummaryLogPage.confirmAndSubmit()
-    // TODO: flag switchover - uncomment the enhanced check-page assertions below (and import EnhancedCheckSummaryLogPage)
-    // await checkBodyText('Upload your summary log', 60)
-    // await checkBodyText('Open periods: new loads', 30)
-    // await checkBodyText('new loads will be recorded', 30)
-    // await checkBodyText('These have been added to your summary log.', 30)
-    // await EnhancedCheckSummaryLogPage.upload()
+    await checkBodyText('Upload your summary log', 60)
+    await checkBodyText('Open periods: new loads', 30)
+    await checkBodyText('new loads will be recorded', 30)
+    await checkBodyText('These have been added to your summary log.', 30)
+    await EnhancedCheckSummaryLogPage.upload()
 
     await checkBodyText('Summary log uploaded', 30)
     await checkBodyTextDoesNotInclude('Your updated waste balance', 10)
@@ -189,21 +181,11 @@ describe('@registered-only', () => {
 
     await checkBodyText('Your summary log is being checked', 30)
 
-    // TODO: flag switchover - remove the legacy check-page assertions below
-    //   (the 'Loads received/exported/sent on' breakdown has no enhanced equivalent)
-    await checkBodyText('Check before confirming upload', 60)
-    await checkBodyText('Check the following before confirming the upload.', 30)
-    await checkBodyText('Loads received', 30)
-    await checkBodyText('Loads exported', 30)
-    await checkBodyText('Loads sent on', 30)
-    await checkBodyText('new loads have been added', 30)
-    await UploadSummaryLogPage.confirmAndSubmit()
-    // TODO: flag switchover - uncomment the enhanced check-page assertions below (and import EnhancedCheckSummaryLogPage)
-    // await checkBodyText('Upload your summary log', 60)
-    // await checkBodyText('Open periods: new loads', 30)
-    // await checkBodyText('new loads will be recorded', 30)
-    // await checkBodyText('These have been added to your summary log.', 30)
-    // await EnhancedCheckSummaryLogPage.upload()
+    await checkBodyText('Upload your summary log', 60)
+    await checkBodyText('Open periods: new loads', 30)
+    await checkBodyText('new loads will be recorded', 30)
+    await checkBodyText('These have been added to your summary log.', 30)
+    await EnhancedCheckSummaryLogPage.upload()
 
     await checkBodyText('Summary log uploaded', 30)
     await checkBodyTextDoesNotInclude('Your updated waste balance', 10)

--- a/test/specs/summarylogs.reprocessor.input.e2e.js
+++ b/test/specs/summarylogs.reprocessor.input.e2e.js
@@ -95,10 +95,7 @@ describe('Summary Logs Reprocessor Input', () => {
 
     await checkBodyText('Your summary log is being checked', 30)
 
-    // TODO: flag switchover - remove the legacy assertion below
-    await checkBodyText('Check before confirming upload', 60)
-    // TODO: flag switchover - uncomment the enhanced assertion below
-    // await checkBodyText('Upload your summary log', 60)
+    await checkBodyText('Upload your summary log', 60)
     await UploadSummaryLogPage.confirmAndCheckDoubleClickPrevented()
 
     await checkBodyText('Your waste records are being updated', 30)

--- a/test/specs/summarylogs.reprocessor.output.e2e.js
+++ b/test/specs/summarylogs.reprocessor.output.e2e.js
@@ -2,6 +2,7 @@ import { $, browser, expect } from '@wdio/globals'
 import DefraIdStubPage from 'page-objects/defra.id.stub.page.js'
 import HomePage from 'page-objects/homepage.js'
 import UploadSummaryLogPage from '../page-objects/upload.summary.log.page.js'
+import EnhancedCheckSummaryLogPage from '../page-objects/enhanced.check.summary.log.page.js'
 import WasteRecordsPage from '../page-objects/waste.records.page.js'
 import DashboardPage from '../page-objects/dashboard.page.js'
 import { checkBodyText } from '../support/checks.js'
@@ -66,15 +67,13 @@ describe('Summary Logs Reprocessor Output', () => {
 
     await checkBodyText('Your summary log is being checked', 30)
 
-    // TODO: flag switchover - remove the legacy check-page assertions below
-    await checkBodyText('Check before confirming upload', 60)
-    await checkBodyText('1 new load will be added to your waste balance', 30)
-    await UploadSummaryLogPage.confirmAndSubmit()
-    // TODO: flag switchover - uncomment the enhanced check-page assertions below (and import EnhancedCheckSummaryLogPage)
-    // await checkBodyText('Upload your summary log', 60)
-    // await checkBodyText('Open periods: new loads', 30)
-    // await checkBodyText('1 new load will be recorded (and will add to your waste balance)', 30)
-    // await EnhancedCheckSummaryLogPage.upload()
+    await checkBodyText('Upload your summary log', 60)
+    await checkBodyText('Open periods: new loads', 30)
+    await checkBodyText(
+      '1 new load will be recorded (and will add to your waste balance)',
+      30
+    )
+    await EnhancedCheckSummaryLogPage.upload()
 
     await checkBodyText('Your waste records are being updated', 30)
 
@@ -103,19 +102,13 @@ describe('Summary Logs Reprocessor Output', () => {
 
     await checkBodyText('Your summary log is being checked', 30)
 
-    // TODO: flag switchover - remove the legacy check-page assertions below
-    await checkBodyText('Check before confirming upload', 60)
+    await checkBodyText('Upload your summary log', 60)
+    await checkBodyText('Open periods: adjusted loads', 30)
     await checkBodyText(
-      '1 adjusted load will be reflected in your waste balance',
+      '1 adjusted load will be recorded (and will reflect in your waste balance)',
       30
     )
-
-    await UploadSummaryLogPage.confirmAndSubmit()
-    // TODO: flag switchover - uncomment the enhanced check-page assertions below (and import EnhancedCheckSummaryLogPage)
-    // await checkBodyText('Upload your summary log', 60)
-    // await checkBodyText('Open periods: adjusted loads', 30)
-    // await checkBodyText('1 adjusted load will be recorded (and will reflect in your waste balance)', 30)
-    // await EnhancedCheckSummaryLogPage.upload()
+    await EnhancedCheckSummaryLogPage.upload()
 
     await checkBodyText('Your waste records are being updated', 30)
 

--- a/test/specs/summarylogs.unhappy.paths.e2e.js
+++ b/test/specs/summarylogs.unhappy.paths.e2e.js
@@ -2,6 +2,7 @@ import { $, browser, expect } from '@wdio/globals'
 import DefraIdStubPage from 'page-objects/defra.id.stub.page.js'
 import HomePage from 'page-objects/homepage.js'
 import UploadSummaryLogPage from '../page-objects/upload.summary.log.page.js'
+import EnhancedCheckSummaryLogPage from '../page-objects/enhanced.check.summary.log.page.js'
 import WasteRecordsPage from '../page-objects/waste.records.page.js'
 import DashboardPage from '../page-objects/dashboard.page.js'
 import {
@@ -513,7 +514,7 @@ describe('Summary Logs - Unhappy paths @unhappyPaths', () => {
       10
     )
 
-    await UploadSummaryLogPage.confirmAndSubmit()
+    await EnhancedCheckSummaryLogPage.upload()
     await checkBodyText('Your waste records are being updated', 30)
     await checkBodyText('Summary log uploaded', 60)
 

--- a/test/specs/summarylogs.unhappy.paths.e2e.js
+++ b/test/specs/summarylogs.unhappy.paths.e2e.js
@@ -450,10 +450,7 @@ describe('Summary Logs - Unhappy paths @unhappyPaths', () => {
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
   })
 
-  // TODO: flag switchover - unskip once FEATURE_FLAG_ENHANCED_SUMMARY_LOG_CHECK_PAGES
-  // is permanently on. The ORS_NOT_FOUND warning only renders on the enhanced check
-  // page, which is currently behind that flag (default on locally, off elsewhere).
-  it.skip('Should warn on the enhanced check page when an OSR_ID has no matching overseas site @orsNotFound', async () => {
+  it('Should warn on the enhanced check page when an OSR_ID has no matching overseas site @orsNotFound', async () => {
     const organisationDetails = await createLinkedOrganisation([
       { material: 'Paper or board (R3)', wasteProcessingType: 'Exporter' }
     ])


### PR DESCRIPTION
Ticket: [PAE-1541](https://eaflood.atlassian.net/browse/PAE-1541)
## What

Turns on `FEATURE_FLAG_ENHANCED_SUMMARY_LOG_CHECK_PAGES` for the `epr-frontend` service in the journey-test compose stack, so the frontend journey tests exercise the new CMA-aware summary log check page (PAE-1541) instead of the legacy one. The enhanced check page is already merged and deployed in `epr-frontend`; this flips the journey suite over to it and completes the switchover that was pre-staged across the specs.

## Changes

**Flag**
- `compose.yml`: set `FEATURE_FLAG_ENHANCED_SUMMARY_LOG_CHECK_PAGES: true` on the `epr-frontend` service.

**Switchover**
- `upload.summary.log.page.js`: collapse the old and enhanced upload helpers into a single `performUploadAndReturnToHomepage` that drives the enhanced page.
- `summarylogs.enhanced.check.cma.e2e.js`: remove the `describe.skip` so the CMA check-page tests run.
- `summarylogs.{reprocessor.input, reprocessor.output, exporter, registered.only}.e2e.js`: replace the legacy check-page assertions with their enhanced equivalents (these were pre-staged as commented blocks in the suite).

**Helper consolidation (after rebase)**
- A later commit on main (PAE-1647, ORS_NOT_FOUND test) reused the legacy `confirmAndSubmit` helper to submit the enhanced page, leaving two submit helpers for the same page. Consolidated onto `EnhancedCheckSummaryLogPage.upload()`, keeping the safer `#main-content`-scoped selector, removed the redundant `confirmAndSubmit`, and pointed the PAE-1647 test at the unified helper.

## Testing

Full headless journey suite against `epr-frontend` / `epr-backend` built from `main`, flag on: **24 passed, 2 failed, 3 skipped**. Both failures are unrelated to this change and confirmed at code level:
- `incomplete.report.submit` passes in isolation (suite-ordering flake).
- `summarylogs.unhappy.paths` uses none of the changed code and fails at login / pre-check timeouts due to shared-session degradation (each test logs in on a shared browser session with no `afterEach` reset, the same issue the CMA spec fixes with `reloadSession`).

Every spec that exercises the enhanced check page passed, including the 8 newly un-skipped CMA tests. `lint` and `lint:types` are clean.

## Deployment dependency

The `@smoketest` and `@sanitycheck` suites run against real environments and now assume the enhanced page (via the shared `performUploadAndReturnToHomepage` helper), so they will only pass where `FEATURE_FLAG_ENHANCED_SUMMARY_LOG_CHECK_PAGES` is enabled. Turning it on in non-prod app-config (dev, test, perf-test) is tracked as a separate task. Prod is deliberately held off for now, so prod smoke/sanity runs need to be gated on the flag or skipped until prod is flipped.

Jira: PAE-1541

[PAE-1541]: https://eaflood.atlassian.net/browse/PAE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ