### PR TITLE
PAE-1649: show reports requiring resubmission

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -205,6 +205,7 @@ services:
       DEFRA_ID_CLIENT_ID: 63983fc2-cfff-45bb-8ec2-959e21062b9a
       DEFRA_ID_OIDC_WELL_KNOWN_URL: http://defra-id-stub:3200/cdp-defra-id-stub/.well-known/openid-configuration
       ENTRA_OIDC_WELL_KNOWN_CONFIGURATION_URL: http://epr-re-ex-entra-stub:3010/.well-known/openid-configuration
+      FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS: true
       FEATURE_FLAG_DEV_ENDPOINTS: true
       GOVUK_NOTIFY_API_KEY: fake-key-for-testing
       MONGO_URI: mongodb://mongodb:27017/
@@ -235,6 +236,7 @@ services:
       DEFRA_ID_OIDC_CONFIGURATION_URL: http://defra-id-stub:3200/cdp-defra-id-stub/.well-known/openid-configuration
       DEFRA_ID_SERVICE_ID: d7d72b79-9c62-ee11-8df0-000d3adf7047
       EPR_BACKEND_URL: http://epr-backend:3001
+      FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS: true
       FEATURE_FLAG_ENHANCED_SUMMARY_LOG_CHECK_PAGES: true
       NODE_ENV: development
       PORT: 3000

--- a/test/specs/reports.requires.resubmission.e2e.js
+++ b/test/specs/reports.requires.resubmission.e2e.js
@@ -1,0 +1,97 @@
+import { browser, expect } from '@wdio/globals'
+import DefraIdStubPage from 'page-objects/defra.id.stub.page.js'
+import HomePage from 'page-objects/homepage.js'
+import UploadSummaryLogPage from '../page-objects/upload.summary.log.page.js'
+import EnhancedCheckSummaryLogPage from '../page-objects/enhanced.check.summary.log.page.js'
+import WasteRecordsPage from '../page-objects/waste.records.page.js'
+import DashboardPage from '../page-objects/dashboard.page.js'
+import { checkBodyText } from '../support/checks.js'
+import {
+  createAndRegisterDefraIdUser,
+  createLinkedOrganisation,
+  linkDefraIdUser,
+  updateMigratedOrganisation,
+  seedSubmittedReport
+} from '../support/apicalls.js'
+
+describe('Reports - requires resubmission @requiresResubmission', () => {
+  // Reset the shared browser session between tests so leftover auth state does
+  // not auto-log-in and skip the stub's user-selection page (see CMA spec).
+  afterEach(async () => {
+    await browser.reloadSession()
+  })
+
+  it('shows a Requires resubmission entry after a summary log restates a closed period @requiresResubmissionStatus @cma', async () => {
+    const organisationDetails = await createLinkedOrganisation([
+      {
+        material: 'Paper or board (R3)',
+        wasteProcessingType: 'Reprocessor',
+        withoutAccreditation: true
+      }
+    ])
+
+    const migrationResponse = await updateMigratedOrganisation(
+      organisationDetails.refNo,
+      [
+        {
+          reprocessingType: 'output',
+          regNumber: 'R25SR500040912PA',
+          status: 'approved',
+          withoutAccreditation: true
+        }
+      ]
+    )
+
+    const user = await createAndRegisterDefraIdUser(migrationResponse.email)
+    await linkDefraIdUser(
+      organisationDetails.refNo,
+      user.userId,
+      migrationResponse.email
+    )
+
+    const regId = migrationResponse.registrationIds[0]
+
+    // Precondition: a submitted (closed) report for Q1 2026.
+    await seedSubmittedReport(
+      organisationDetails.refNo,
+      regId,
+      user.userId,
+      2026,
+      'quarterly',
+      1,
+      1,
+      { tonnageRecycled: 100, tonnageNotRecycled: 0 }
+    )
+
+    await HomePage.open()
+    await HomePage.clickStartNow()
+    await DefraIdStubPage.loginViaEmail(migrationResponse.email)
+
+    await DashboardPage.selectLink(1)
+    await WasteRecordsPage.submitSummaryLogLink()
+
+    // Upload a summary log that restates the closed Q1 2026 period, and confirm
+    // it. On submit the backend flags that period's report for resubmission.
+    await UploadSummaryLogPage.uploadFile(
+      'resources/reprocessor-output-regonly-cma.xlsx'
+    )
+    await UploadSummaryLogPage.continue()
+    await checkBodyText('Your summary log is being checked', 30)
+    await checkBodyText('Upload your summary log', 60)
+    await checkBodyText('Closed periods: new loads', 30)
+
+    await EnhancedCheckSummaryLogPage.upload()
+    await checkBodyText('Your waste records are being updated', 30)
+    await checkBodyText('Summary log uploaded', 60)
+    await UploadSummaryLogPage.clickOnReturnToHomePage()
+
+    // The Reports landing page now shows a "Requires resubmission" entry for the
+    // restated period.
+    await DashboardPage.selectLink(1)
+    await WasteRecordsPage.manageReportsLink()
+    await checkBodyText('Requires resubmission', 30)
+
+    await HomePage.signOut()
+    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+  })
+})


### PR DESCRIPTION
Ticket: [PAE-1649](https://eaflood.atlassian.net/browse/PAE-1649)

journey test for PAE-1649: end-to-end check that a "Requires resubmission" entry appears on the operator's Reports landing page after a summary log restates an already-submitted (closed) period.

- seed a submitted Q1 2026 report, upload a summary log that restates that closed period, confirm the upload, then assert "Requires resubmission" on the reports page
- mirrors the PAE-1648 CMA upload flow; runs against the matching fe/be branch in CI

paired with DEFRA/epr-frontend#908 and DEFRA/epr-backend#1403.


[PAE-1649]: https://eaflood.atlassian.net/browse/PAE-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ