### PR TITLE
PAE-1597: Remove enhanced summary log check pages flag

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -241,7 +241,6 @@ services:
       # leg, and a plain `docker compose up`) it defaults on: the shipping
       # behaviour the suite validates. See test/support/flags.js.
       FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS: ${FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS:-true}
-      FEATURE_FLAG_ENHANCED_SUMMARY_LOG_CHECK_PAGES: true
       NODE_ENV: development
       PORT: 3000
       REDIS_HOST: redis

--- a/test/page-objects/upload.summary.log.page.js
+++ b/test/page-objects/upload.summary.log.page.js
@@ -10,8 +10,6 @@ class UploadSummaryLogPage extends SummaryLogUploadActions {
     return await element.getText()
   }
 
-  // The enhanced (CMA) upload flow, now the only check page after the
-  // FEATURE_FLAG_ENHANCED_SUMMARY_LOG_CHECK_PAGES switchover.
   async performUploadAndReturnToHomepage(filePath) {
     await this.uploadFile(filePath)
     await this.continue()


### PR DESCRIPTION
Ticket: [PAE-1597](https://eaflood.atlassian.net/browse/PAE-1597)
## What changed

- **`compose.yml`** (line 244): removed the `FEATURE_FLAG_ENHANCED_SUMMARY_LOG_CHECK_PAGES: true` environment variable from the frontend service definition. The flag is retired and no longer read by the application.
- **`test/page-objects/upload.summary.log.page.js`** (lines 13–14): removed a stale comment that referred to the flag switchover. The method itself is unchanged — it already exercised the enhanced (CMA) check-page flow exclusively, which is now the permanent behaviour with no flag gate.

## Why

`FEATURE_FLAG_ENHANCED_SUMMARY_LOG_CHECK_PAGES` has been removed from epr-frontend as part of PAE-1597. Keeping it in `compose.yml` would inject an env var that the app no longer recognises, and the comment in the page object was only meaningful during the rollout period.


[PAE-1597]: https://eaflood.atlassian.net/browse/PAE-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ