### PR TITLE
PAE-1649: default closed-period-adjustments flag on in journey ci

### DIFF
--- a/run-journey-tests/action.yml
+++ b/run-journey-tests/action.yml
@@ -16,7 +16,7 @@ inputs:
       matrix runs the suite once per flag state. The value is dual-exported (see
       the first step below) to both the frontend container and the wdio runner,
       so the test view of the flag cannot drift from app behaviour.
-    default: 'false'
+    default: 'true'
 
 runs:
   using: 'composite'


### PR DESCRIPTION
Ticket: [PAE-1649](https://eaflood.atlassian.net/browse/PAE-1649)
the `run-journey-tests` action input `feature-flag-closed-period-adjustments` defaulted to `'false'`, out of step with `compose.yml` (`${...:-true}`) and the matrix baseline (`|| 'true'`), both of which default the flag **on**.

because fe/be PRs call `run-journey-tests@main` without passing the flag, they picked up that `'false'` default and ran the whole suite flag-**off** — so any spec asserting the flag-on closed-period messaging (the PAE-1648 cma banner / further-action copy) failed on every fe/be PR journey run.

flip the default to `'true'` so it matches compose + baseline. the messaging is already on fe `main` and flag-gated, so flag-on renders it and the specs pass. matrix legs still override this explicitly to pin either state.

[PAE-1649]: https://eaflood.atlassian.net/browse/PAE-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ