### PR TITLE
PAE-1650: Cover resubmission draft creation in the journey test

### DIFF
--- a/test/page-objects/reports/reports.page.js
+++ b/test/page-objects/reports/reports.page.js
@@ -9,16 +9,37 @@ const tableAfterHeadingXPath = (heading) =>
 const rowXPath = (tableXPath, rowIndex) =>
   `${tableXPath}//tbody/tr[${rowIndex}]`
 
-// selectActionLink and getActionLinkText both key off the first govuk-link in
-// the row, which assumes each row exposes exactly one action anchor (the period
-// cell is plain text). If a row ever gains a second link, target the action
-// column explicitly instead.
+// The action-link helpers key off the first govuk-link in the row, which
+// assumes each row exposes exactly one action anchor (the period cell is plain
+// text). If a row ever gains a second link, target the action column explicitly
+// instead.
 const selectActionLink = async (rowIndex, tableXPath) => {
   const linkElement = await $(
     `${rowXPath(tableXPath, rowIndex)}//a[contains(@class,'govuk-link')]`
   )
   await linkElement.waitForClickable({ timeout: 5000 })
   await linkElement.click()
+}
+
+// The action anchor carries a govuk-visually-hidden period suffix for screen
+// readers (e.g. "Review and create draft" + "Quarter 1, 2026"), so match on the
+// visible label as a substring rather than an exact string.
+const actionLinkByTextXPath = (rowIndex, tableXPath, label) =>
+  `${rowXPath(tableXPath, rowIndex)}//a[contains(@class,'govuk-link')][contains(normalize-space(), '${label}')]`
+
+const selectActionLinkByText = async (rowIndex, tableXPath, label) => {
+  const linkElement = await $(
+    actionLinkByTextXPath(rowIndex, tableXPath, label)
+  )
+  await linkElement.waitForClickable({ timeout: 5000 })
+  await linkElement.click()
+}
+
+const expectActionLink = async (rowIndex, tableXPath, label) => {
+  const linkElement = await $(
+    actionLinkByTextXPath(rowIndex, tableXPath, label)
+  )
+  await linkElement.waitForExist({ timeout: 5000 })
 }
 
 const getStatusBadgeElement = async (rowIndex, tableXPath) => {
@@ -41,14 +62,6 @@ const getStatusColour = async (rowIndex, tableXPath) => {
   return match ? match[1] : 'blue'
 }
 
-const getActionLinkText = async (rowIndex, tableXPath) => {
-  const element = await $(
-    `${rowXPath(tableXPath, rowIndex)}//a[contains(@class,'govuk-link')]`
-  )
-  await element.waitForExist({ timeout: 5000 })
-  return await element.getText()
-}
-
 const activeTableXPath = tableAfterHeadingXPath(ACTIVE_HEADING)
 const submittedTableXPath = tableAfterHeadingXPath(SUBMITTED_HEADING)
 
@@ -67,12 +80,16 @@ class ReportsPage {
     await selectActionLink(rowIndex, submittedTableXPath)
   }
 
-  async getActiveStatusBadge(rowIndex) {
-    return await getStatusBadge(rowIndex, activeTableXPath)
+  async selectActiveActionLinkByText(rowIndex, label) {
+    await selectActionLinkByText(rowIndex, activeTableXPath, label)
   }
 
-  async getActiveActionLinkText(rowIndex) {
-    return await getActionLinkText(rowIndex, activeTableXPath)
+  async expectActiveActionLink(rowIndex, label) {
+    await expectActionLink(rowIndex, activeTableXPath, label)
+  }
+
+  async getActiveStatusBadge(rowIndex) {
+    return await getStatusBadge(rowIndex, activeTableXPath)
   }
 
   async getSubmittedStatusBadge(rowIndex) {

--- a/test/page-objects/reports/reports.page.js
+++ b/test/page-objects/reports/reports.page.js
@@ -37,6 +37,14 @@ const getStatusColour = async (rowIndex, tableXPath) => {
   return match ? match[1] : 'blue'
 }
 
+const getActionLinkText = async (rowIndex, tableXPath) => {
+  const element = await $(
+    `${rowXPath(tableXPath, rowIndex)}//a[contains(@class,'govuk-link')]`
+  )
+  await element.waitForExist({ timeout: 5000 })
+  return await element.getText()
+}
+
 const activeTableXPath = tableAfterHeadingXPath(ACTIVE_HEADING)
 const submittedTableXPath = tableAfterHeadingXPath(SUBMITTED_HEADING)
 
@@ -57,6 +65,10 @@ class ReportsPage {
 
   async getActiveStatusBadge(rowIndex) {
     return await getStatusBadge(rowIndex, activeTableXPath)
+  }
+
+  async getActiveActionLinkText(rowIndex) {
+    return await getActionLinkText(rowIndex, activeTableXPath)
   }
 
   async getSubmittedStatusBadge(rowIndex) {

--- a/test/page-objects/reports/reports.page.js
+++ b/test/page-objects/reports/reports.page.js
@@ -9,6 +9,10 @@ const tableAfterHeadingXPath = (heading) =>
 const rowXPath = (tableXPath, rowIndex) =>
   `${tableXPath}//tbody/tr[${rowIndex}]`
 
+// selectActionLink and getActionLinkText both key off the first govuk-link in
+// the row, which assumes each row exposes exactly one action anchor (the period
+// cell is plain text). If a row ever gains a second link, target the action
+// column explicitly instead.
 const selectActionLink = async (rowIndex, tableXPath) => {
   const linkElement = await $(
     `${rowXPath(tableXPath, rowIndex)}//a[contains(@class,'govuk-link')]`

--- a/test/page-objects/reports/resubmission.explainer.page.js
+++ b/test/page-objects/reports/resubmission.explainer.page.js
@@ -1,0 +1,22 @@
+import { $ } from '@wdio/globals'
+
+class ResubmissionExplainerPage {
+  async headingText() {
+    const element = await $('h1.govuk-heading-xl')
+    await element.waitForExist({ timeout: 5000 })
+    return await element.getText()
+  }
+
+  // The Continue action is a govukButton rendered with an href, so it is an
+  // anchor styled as a button (a GET link to the detail page), not a form
+  // submit. It is the only govuk-button anchor on the explainer.
+  async continue() {
+    await $('a.govuk-button').click()
+  }
+
+  async cancelAndReturnHome() {
+    await $('a*=Cancel and return to home').click()
+  }
+}
+
+export default new ResubmissionExplainerPage()

--- a/test/page-objects/reports/resubmission.explainer.page.js
+++ b/test/page-objects/reports/resubmission.explainer.page.js
@@ -13,10 +13,6 @@ class ResubmissionExplainerPage {
   async continue() {
     await $('a.govuk-button').click()
   }
-
-  async cancelAndReturnHome() {
-    await $('a*=Cancel and return to home').click()
-  }
 }
 
 export default new ResubmissionExplainerPage()

--- a/test/specs/reports.requires.resubmission.e2e.js
+++ b/test/specs/reports.requires.resubmission.e2e.js
@@ -101,7 +101,7 @@ describe('Reports - requires resubmission @requiresResubmission', () => {
     expect(await ReportsPage.getActiveStatusBadge(1)).toBe(
       'Requires resubmission'
     )
-    expect(await ReportsPage.getActiveActionLinkText(1)).toContain(
+    expect(await ReportsPage.getActiveActionLinkText(1)).toBe(
       'Review and create draft'
     )
 
@@ -119,6 +119,9 @@ describe('Reports - requires resubmission @requiresResubmission', () => {
     )
     await ReportDetailPage.useThisData()
 
+    // Creating the draft redirects into the wizard at the first data page.
+    expect(await TonnesRecycledPage.headingText()).toBeTruthy()
+
     // --- Intermediate stage: revisit the landing before submitting ---
     // The draft now exists but is not yet ready to submit, so the period keeps
     // its "Requires resubmission" status and the CTA becomes "Continue".
@@ -126,7 +129,7 @@ describe('Reports - requires resubmission @requiresResubmission', () => {
     expect(await ReportsPage.getActiveStatusBadge(1)).toBe(
       'Requires resubmission'
     )
-    expect(await ReportsPage.getActiveActionLinkText(1)).toContain('Continue')
+    expect(await ReportsPage.getActiveActionLinkText(1)).toBe('Continue')
 
     // --- Resume and complete the draft ---
     await ReportsPage.selectActiveActionLink(1)
@@ -154,7 +157,7 @@ describe('Reports - requires resubmission @requiresResubmission', () => {
     expect(await ReportsPage.getActiveStatusBadge(1)).toBe(
       'Requires resubmission'
     )
-    expect(await ReportsPage.getActiveActionLinkText(1)).toContain(
+    expect(await ReportsPage.getActiveActionLinkText(1)).toBe(
       'Review and submit'
     )
     expect(await ReportsPage.getSubmittedStatusBadge(1)).toBe('Submitted')

--- a/test/specs/reports.requires.resubmission.e2e.js
+++ b/test/specs/reports.requires.resubmission.e2e.js
@@ -5,6 +5,14 @@ import UploadSummaryLogPage from '../page-objects/upload.summary.log.page.js'
 import EnhancedCheckSummaryLogPage from '../page-objects/enhanced.check.summary.log.page.js'
 import WasteRecordsPage from '../page-objects/waste.records.page.js'
 import DashboardPage from '../page-objects/dashboard.page.js'
+import ReportsPage from 'page-objects/reports/reports.page.js'
+import ResubmissionExplainerPage from 'page-objects/reports/resubmission.explainer.page.js'
+import ReportDetailPage from 'page-objects/reports/report.detail.page.js'
+import TonnesRecycledPage from 'page-objects/reports/tonnes.recycled.page.js'
+import TonnesNotRecycledPage from 'page-objects/reports/tonnes.not.recycled.page.js'
+import ReportSupportingInformationPage from 'page-objects/reports/report.supporting.information.page.js'
+import ReportCheckAnswersPage from 'page-objects/reports/report.check.answers.page.js'
+import ConfirmationPage from 'page-objects/reports/confirmation.page.js'
 import { checkBodyText } from '../support/checks.js'
 import {
   createAndRegisterDefraIdUser,
@@ -21,7 +29,7 @@ describe('Reports - requires resubmission @requiresResubmission', () => {
     await browser.reloadSession()
   })
 
-  it('shows a Requires resubmission entry after a summary log restates a closed period @requiresResubmissionStatus @cma', async () => {
+  it('creates a resubmission draft from a restated closed period, showing the intermediate Continue CTA before the final Review and submit CTA @requiresResubmissionStatus @cma', async () => {
     const organisationDetails = await createLinkedOrganisation([
       {
         material: 'Paper or board (R3)',
@@ -86,10 +94,70 @@ describe('Reports - requires resubmission @requiresResubmission', () => {
     await UploadSummaryLogPage.clickOnReturnToHomePage()
 
     // The Reports landing page now shows a "Requires resubmission" entry for the
-    // restated period.
+    // restated period, with a "Review and create draft" call to action.
     await DashboardPage.selectLink(1)
     await WasteRecordsPage.manageReportsLink()
     await checkBodyText('Requires resubmission', 30)
+    expect(await ReportsPage.getActiveStatusBadge(1)).toBe(
+      'Requires resubmission'
+    )
+    expect(await ReportsPage.getActiveActionLinkText(1)).toContain(
+      'Review and create draft'
+    )
+
+    // --- Resubmission explainer ---
+    await ReportsPage.selectActiveActionLink(1)
+    expect(await ResubmissionExplainerPage.headingText()).toContain(
+      'needs to be resubmitted'
+    )
+    await checkBodyText('You need to create a new draft report', 10)
+    await ResubmissionExplainerPage.continue()
+
+    // --- Summary log data preview: create the draft ---
+    expect(await ReportDetailPage.headingText()).toContain(
+      'Your summary log data'
+    )
+    await ReportDetailPage.useThisData()
+
+    // --- Intermediate stage: revisit the landing before submitting ---
+    // The draft now exists but is not yet ready to submit, so the period keeps
+    // its "Requires resubmission" status and the CTA becomes "Continue".
+    await TonnesRecycledPage.selectBackLink()
+    expect(await ReportsPage.getActiveStatusBadge(1)).toBe(
+      'Requires resubmission'
+    )
+    expect(await ReportsPage.getActiveActionLinkText(1)).toContain('Continue')
+
+    // --- Resume and complete the draft ---
+    await ReportsPage.selectActiveActionLink(1)
+    await TonnesRecycledPage.enterTonnage('12.50')
+    await TonnesRecycledPage.continue()
+    await TonnesNotRecycledPage.enterTonnage('7.50')
+    await TonnesNotRecycledPage.continue()
+
+    // Supporting information shows the resubmission-variant heading.
+    expect(await ReportSupportingInformationPage.headingText()).toBe(
+      'Add supporting information to help your regulator'
+    )
+    await ReportSupportingInformationPage.continue()
+
+    await ReportCheckAnswersPage.createReport()
+
+    // --- Confirmation: resubmission variant keeps the resubmission status ---
+    await checkBodyText('draft report created', 30)
+    await checkBodyText('Requires resubmission', 10)
+    await checkBodyText('as soon as possible', 10)
+    await ConfirmationPage.goToReports()
+
+    // --- End state: status unchanged, CTA flips to "Review and submit" and the
+    // original submitted report remains visible in the Submitted table. ---
+    expect(await ReportsPage.getActiveStatusBadge(1)).toBe(
+      'Requires resubmission'
+    )
+    expect(await ReportsPage.getActiveActionLinkText(1)).toContain(
+      'Review and submit'
+    )
+    expect(await ReportsPage.getSubmittedStatusBadge(1)).toBe('Submitted')
 
     await HomePage.signOut()
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))

--- a/test/specs/reports.requires.resubmission.e2e.js
+++ b/test/specs/reports.requires.resubmission.e2e.js
@@ -101,12 +101,10 @@ describe('Reports - requires resubmission @requiresResubmission', () => {
     expect(await ReportsPage.getActiveStatusBadge(1)).toBe(
       'Requires resubmission'
     )
-    expect(await ReportsPage.getActiveActionLinkText(1)).toBe(
-      'Review and create draft'
-    )
-
     // --- Resubmission explainer ---
-    await ReportsPage.selectActiveActionLink(1)
+    // Clicking the CTA by its label also asserts it reads "Review and create
+    // draft" (a wrong label leaves nothing to click).
+    await ReportsPage.selectActiveActionLinkByText(1, 'Review and create draft')
     expect(await ResubmissionExplainerPage.headingText()).toContain(
       'needs to be resubmitted'
     )
@@ -129,10 +127,9 @@ describe('Reports - requires resubmission @requiresResubmission', () => {
     expect(await ReportsPage.getActiveStatusBadge(1)).toBe(
       'Requires resubmission'
     )
-    expect(await ReportsPage.getActiveActionLinkText(1)).toBe('Continue')
-
     // --- Resume and complete the draft ---
-    await ReportsPage.selectActiveActionLink(1)
+    // Clicking by label also asserts the CTA has flipped to "Continue".
+    await ReportsPage.selectActiveActionLinkByText(1, 'Continue')
     await TonnesRecycledPage.enterTonnage('12.50')
     await TonnesRecycledPage.continue()
     await TonnesNotRecycledPage.enterTonnage('7.50')
@@ -157,9 +154,7 @@ describe('Reports - requires resubmission @requiresResubmission', () => {
     expect(await ReportsPage.getActiveStatusBadge(1)).toBe(
       'Requires resubmission'
     )
-    expect(await ReportsPage.getActiveActionLinkText(1)).toBe(
-      'Review and submit'
-    )
+    await ReportsPage.expectActiveActionLink(1, 'Review and submit')
     expect(await ReportsPage.getSubmittedStatusBadge(1)).toBe('Submitted')
 
     await HomePage.signOut()


### PR DESCRIPTION
Ticket: [PAE-1650](https://eaflood.atlassian.net/browse/PAE-1650)
## What

Extends the "requires resubmission" frontend journey test (`reports.requires.resubmission.e2e.js`) to cover the full resubmission draft-creation journey, not just the point where a restated closed period first appears as "Requires resubmission".

After the existing precondition (a submitted closed period restated via a summary-log upload through the enhanced check), the scenario now walks the whole flow:

1. The landing page shows "Requires resubmission" with a "Review and create draft" call to action.
2. The resubmission explainer page.
3. The summary-log data preview, where "Use this data" creates the draft.
4. A mid-flow revisit to the landing page, before the draft is submitted, asserting the period keeps its "Requires resubmission" status and the call to action becomes "Continue".
5. Resuming and completing the draft, including the resubmission variant of the supporting-information page.
6. The confirmation page, which keeps the "Requires resubmission" status and the "as soon as possible" guidance.
7. The landing end state, where the status is unchanged but the call to action flips to "Review and submit", with the original submitted report still visible in the Submitted table.

Supporting changes:

- Adds a `resubmission.explainer.page.js` page object.
- Adds `getActiveActionLinkText()` to `reports.page.js` so the call-to-action label can be asserted at each stage.

## Why

These screens are delivered by the epr-frontend PAE-1650 work, and were previously only covered by that repository's integration tests. This extends coverage to the real end-to-end journey, in particular the three-way call-to-action branching on the landing page (create draft, continue, review and submit) and the intermediate in-progress state.

Assertions target page semantics (status text and call-to-action label and target, and the original report remaining in Submitted) rather than visual styling, which stays with the frontend component tests.

## Scope: registered-only reprocessor

The scenario deliberately builds on a registered-only (unaccredited) reprocessor, reusing the existing precondition in this spec. This is the right base for the behaviour under test: the resubmission screens (explainer, supporting-information variant, confirmation variant and the landing call-to-action branching) are all keyed on the submission number being greater than one, so they are agnostic to registration type and accreditation, and a reprocessor enters the wizard at the same first page (tonnes recycled) with or without accreditation. The registered-only path therefore exercises every new PAE-1650 screen with the fewest wizard steps.

What it intentionally does not cover at journey level is the accredited path, where the free-PRN pages sit inside the wizard, and the exporter PERN variant of the supporting-information copy. Those per-registration-type variants are covered by the frontend integration tests, and an accredited-reprocessor resubmission journey can follow as a separate scenario if we want end-to-end coverage of the PRN steps.

## Notes for reviewers

The test exercises screens from the epr-frontend PAE-1650 branch, so it relies on the journey CI building the frontend image from the matching branch name. It will only pass once that frontend change is available to the build.


[PAE-1650]: https://eaflood.atlassian.net/browse/PAE-1650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ