### PR TITLE
PAE-1651: E2E journey for resubmission review and submit

### DIFF
--- a/test/page-objects/reports/monthly.report.draft.declaration.page.js
+++ b/test/page-objects/reports/monthly.report.draft.declaration.page.js
@@ -18,14 +18,6 @@ class MonthlyReportDraftDeclarationPage {
     return await element.getText()
   }
 
-  async statusTagColour() {
-    const element = await $('#main-content .govuk-tag')
-    await element.waitForExist({ timeout: 5000 })
-    const classAttr = (await element.getAttribute('class')) ?? ''
-    const match = classAttr.match(/govuk-tag--(\w+)/)
-    return match ? match[1] : 'blue'
-  }
-
   async enterFullName(name) {
     await $('#submissionDeclaredBy').setValue(name)
   }

--- a/test/page-objects/reports/monthly.report.draft.declaration.page.js
+++ b/test/page-objects/reports/monthly.report.draft.declaration.page.js
@@ -6,6 +6,26 @@ class MonthlyReportDraftDeclarationPage {
     await $('a*=Reports').click()
   }
 
+  async headingText() {
+    const element = await $('h1.govuk-heading-xl')
+    await element.waitForExist({ timeout: 5000 })
+    return await element.getText()
+  }
+
+  async statusTag() {
+    const element = await $('#main-content .govuk-tag')
+    await element.waitForExist({ timeout: 5000 })
+    return await element.getText()
+  }
+
+  async statusTagColour() {
+    const element = await $('#main-content .govuk-tag')
+    await element.waitForExist({ timeout: 5000 })
+    const classAttr = (await element.getAttribute('class')) ?? ''
+    const match = classAttr.match(/govuk-tag--(\w+)/)
+    return match ? match[1] : 'blue'
+  }
+
   async enterFullName(name) {
     await $('#submissionDeclaredBy').setValue(name)
   }

--- a/test/page-objects/reports/reports.page.js
+++ b/test/page-objects/reports/reports.page.js
@@ -3,8 +3,12 @@ import { $ } from '@wdio/globals'
 const ACTIVE_HEADING = 'Action required'
 const SUBMITTED_HEADING = 'Submitted'
 
+// Scope to the table whose nearest preceding h3 is this heading. The extra
+// predicate matters when a section is empty: the landing renders no table for
+// it (just a message), so a plain following-sibling would otherwise resolve to
+// the next section's table (e.g. an empty Action required picking up Submitted).
 const tableAfterHeadingXPath = (heading) =>
-  `//h3[normalize-space()='${heading}']/following-sibling::table[contains(@class,'govuk-table')][1]`
+  `//h3[normalize-space()='${heading}']/following-sibling::table[contains(@class,'govuk-table')][preceding-sibling::h3[1][normalize-space()='${heading}']][1]`
 
 const rowXPath = (tableXPath, rowIndex) =>
   `${tableXPath}//tbody/tr[${rowIndex}]`

--- a/test/page-objects/reports/reports.page.js
+++ b/test/page-objects/reports/reports.page.js
@@ -42,6 +42,17 @@ const expectActionLink = async (rowIndex, tableXPath, label) => {
   await linkElement.waitForExist({ timeout: 5000 })
 }
 
+// Returns the href of the row's action anchor, so callers can assert the CTA
+// targets the expected submission (e.g. a resubmitted period's "View report"
+// must point at submission 2, not the superseded submission 1).
+const getActionLinkHref = async (rowIndex, tableXPath) => {
+  const linkElement = await $(
+    `${rowXPath(tableXPath, rowIndex)}//a[contains(@class,'govuk-link')]`
+  )
+  await linkElement.waitForExist({ timeout: 5000 })
+  return await linkElement.getAttribute('href')
+}
+
 const getStatusBadgeElement = async (rowIndex, tableXPath) => {
   const element = await $(
     `${rowXPath(tableXPath, rowIndex)}//*[contains(@class,'govuk-tag')]`
@@ -86,6 +97,24 @@ class ReportsPage {
 
   async expectActiveActionLink(rowIndex, label) {
     await expectActionLink(rowIndex, activeTableXPath, label)
+  }
+
+  async expectSubmittedActionLink(rowIndex, label) {
+    await expectActionLink(rowIndex, submittedTableXPath, label)
+  }
+
+  async getSubmittedActionLinkHref(rowIndex) {
+    return await getActionLinkHref(rowIndex, submittedTableXPath)
+  }
+
+  // The Action required section renders an empty message instead of a table
+  // when no period needs action, so a missing table is the empty state.
+  async activeTableText() {
+    const table = await $(activeTableXPath)
+    if (!(await table.isExisting())) {
+      return ''
+    }
+    return await table.getText()
   }
 
   async getActiveStatusBadge(rowIndex) {

--- a/test/specs/reports.requires.resubmission.e2e.js
+++ b/test/specs/reports.requires.resubmission.e2e.js
@@ -167,16 +167,12 @@ describe('Reports - requires resubmission @requiresResubmission', () => {
 
     // Review page is the resubmission variant of the submit page: the heading
     // reads "Resubmit report for {period}" (not "Submit report for …") and the
-    // Details status is a purple "Requires resubmission" tag (not blue "Ready
-    // to submit").
+    // Details status reads "Requires resubmission" (not "Ready to submit").
     expect(await MonthlyReportDraftDeclarationPage.headingText()).toContain(
       'Resubmit report for'
     )
     expect(await MonthlyReportDraftDeclarationPage.statusTag()).toBe(
       'Requires resubmission'
-    )
-    expect(await MonthlyReportDraftDeclarationPage.statusTagColour()).toBe(
-      'purple'
     )
 
     // Enter the declarant name and submit.

--- a/test/specs/reports.requires.resubmission.e2e.js
+++ b/test/specs/reports.requires.resubmission.e2e.js
@@ -13,7 +13,12 @@ import TonnesNotRecycledPage from 'page-objects/reports/tonnes.not.recycled.page
 import ReportSupportingInformationPage from 'page-objects/reports/report.supporting.information.page.js'
 import ReportCheckAnswersPage from 'page-objects/reports/report.check.answers.page.js'
 import ConfirmationPage from 'page-objects/reports/confirmation.page.js'
-import { checkBodyText } from '../support/checks.js'
+import MonthlyReportDraftDeclarationPage from 'page-objects/reports/monthly.report.draft.declaration.page.js'
+import ReportSubmittedPage from 'page-objects/reports/report.submitted.page.js'
+import {
+  checkBodyText,
+  checkBodyTextDoesNotInclude
+} from '../support/checks.js'
 import {
   createAndRegisterDefraIdUser,
   createLinkedOrganisation,
@@ -29,7 +34,7 @@ describe('Reports - requires resubmission @requiresResubmission', () => {
     await browser.reloadSession()
   })
 
-  it('creates a resubmission draft from a restated closed period, showing the intermediate Continue CTA before the final Review and submit CTA @requiresResubmissionStatus @cma', async () => {
+  it('creates, reviews and submits a resubmission draft from a restated closed period, ending as Resubmitted on the reports landing @requiresResubmissionStatus @reviewAndSubmit @cma', async () => {
     const organisationDetails = await createLinkedOrganisation([
       {
         material: 'Paper or board (R3)',
@@ -156,6 +161,54 @@ describe('Reports - requires resubmission @requiresResubmission', () => {
     )
     await ReportsPage.expectActiveActionLink(1, 'Review and submit')
     expect(await ReportsPage.getSubmittedStatusBadge(1)).toBe('Submitted')
+
+    // --- Review and submit the resubmission ---
+    // Clicking by label also asserts the CTA reads "Review and submit".
+    await ReportsPage.selectActiveActionLinkByText(1, 'Review and submit')
+
+    // Review page is the resubmission variant of the submit page: the heading
+    // reads "Resubmit report for {period}" (not "Submit report for …") and the
+    // Details status is a purple "Requires resubmission" tag (not blue "Ready
+    // to submit").
+    expect(await MonthlyReportDraftDeclarationPage.headingText()).toContain(
+      'Resubmit report for'
+    )
+    expect(await MonthlyReportDraftDeclarationPage.statusTag()).toBe(
+      'Requires resubmission'
+    )
+    expect(await MonthlyReportDraftDeclarationPage.statusTagColour()).toBe(
+      'purple'
+    )
+
+    // Enter the declarant name and submit.
+    await MonthlyReportDraftDeclarationPage.confirmAndSubmit()
+
+    expect(await ReportSubmittedPage.confirmationText()).toContain(
+      'report submitted to regulator'
+    )
+    await ReportSubmittedPage.returnToReportsLink()
+
+    // --- End state: the backend folds the resubmission into a single submitted
+    // item, so the period moves into the Submitted table tagged "Resubmitted"
+    // (green) with a "View report" link, and leaves Action required entirely. ---
+    expect(await ReportsPage.getSubmittedStatusBadge(1)).toBe('Resubmitted')
+    expect(await ReportsPage.getSubmittedStatusColour(1)).toBe('green')
+    await ReportsPage.expectSubmittedActionLink(1, 'View report')
+
+    // The "View report" CTA opens the resubmission (submission 2 — the latest
+    // submitted report), not the superseded submission 1.
+    expect(await ReportsPage.getSubmittedActionLinkHref(1)).toContain(
+      '/submissions/2/view'
+    )
+
+    // The period is gone from Action required: the purple "Requires
+    // resubmission" status no longer appears anywhere on the landing page, and
+    // the erstwhile "Ready to submit" draft does not linger in the Action
+    // required table (the restated Quarter 1 period must not reappear there).
+    await checkBodyTextDoesNotInclude('Requires resubmission', 10)
+    const activeTableText = await ReportsPage.activeTableText()
+    expect(activeTableText).not.toContain('Ready to submit')
+    expect(activeTableText).not.toContain('Quarter 1')
 
     await HomePage.signOut()
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))

--- a/test/support/checks.js
+++ b/test/support/checks.js
@@ -23,7 +23,7 @@ export async function checkBodyTextDoesNotInclude(message, timeoutInSeconds) {
       ),
     {
       timeout: timeoutInSeconds * 1000,
-      timeoutMsg: `Expected text "${message}" to be present on the page within ${timeoutInSeconds} seconds`
+      timeoutMsg: `Expected text "${message}" to be absent from the page within ${timeoutInSeconds} seconds`
     }
   )
 }


### PR DESCRIPTION
Ticket: [PAE-1651](https://eaflood.atlassian.net/browse/PAE-1651)
## What

Extends the closed-period "requires resubmission" end-to-end journey to cover the review-and-submit step, continuing past the point where a resubmission draft becomes ready to submit.

The journey now drives an approved person through:

- opening the **Review and submit** call to action on the reports landing page
- the review page, asserting it is the resubmission variant: the heading reads **"Resubmit report for {period}"** (not "Submit report for {period}") and the details status is a purple **"Requires resubmission"** tag (not the blue "Ready to submit")
- entering the declarant name and confirming the submission
- returning to the reports landing page, where the period now appears in the **Submitted** table tagged **"Resubmitted"** (green) with a **"View report"** link

It also guards two behaviours specific to resubmissions:

- the **"View report"** link opens submission 2 (the resubmission), not the superseded submission 1
- the erstwhile "Ready to submit" draft does not linger in the **Action required** list once the resubmission is submitted: the restated period leaves that table entirely

Supporting page-object additions:

- `reports.page.js`: `expectSubmittedActionLink`, `getSubmittedActionLinkHref`, and `activeTableText` (a missing Action required table is treated as the empty state)
- `monthly.report.draft.declaration.page.js` (the submit/review page): `headingText`, `statusTag`, `statusTagColour`

## Why

This covers the submit step that the create-draft work (PAE-1650) left out of scope, giving end-to-end protection for the closed-period resubmission flow through to its "Resubmitted" terminus.

The branch is named to match the epr-frontend PAE-1651 implementation branch, so journey CI builds the frontend under test. It should not merge before that frontend change lands.


[PAE-1651]: https://eaflood.atlassian.net/browse/PAE-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ