### PR TITLE
Add test to check reports only required from accreditation date

### DIFF
--- a/test/page-objects/reports/reports.page.js
+++ b/test/page-objects/reports/reports.page.js
@@ -1,4 +1,4 @@
-import { $ } from '@wdio/globals'
+import { $, $$ } from '@wdio/globals'
 
 const ACTIVE_HEADING = 'Action required'
 const SUBMITTED_HEADING = 'Submitted'
@@ -135,6 +135,10 @@ class ReportsPage {
 
   async getSubmittedStatusColour(rowIndex) {
     return await getStatusColour(rowIndex, submittedTableXPath)
+  }
+
+  async getActiveNumberOfRows() {
+    return (await $$(activeTableXPath + '//tbody/tr')).length
   }
 }
 

--- a/test/page-objects/reports/reports.page.js
+++ b/test/page-objects/reports/reports.page.js
@@ -99,6 +99,10 @@ class ReportsPage {
     await selectActionLinkByText(rowIndex, activeTableXPath, label)
   }
 
+  async getActivePeriodLabel(rowIndex) {
+    return await $(`${rowXPath(activeTableXPath, rowIndex)}//td[1]`).getText()
+  }
+
   async expectActiveActionLink(rowIndex, label) {
     await expectActionLink(rowIndex, activeTableXPath, label)
   }

--- a/test/specs/report.accreditation.date.e2e.js
+++ b/test/specs/report.accreditation.date.e2e.js
@@ -28,9 +28,9 @@ describe('Report only shows from accreditation validFrom date — exporter @vali
       }
     ])
 
-    const dateToday = new Date(
-      new Date().setMonth(new Date().getMonth() - 1)
-    ).toLocaleDateString('en-CA')
+    const now = new Date()
+    const lastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+    const dateToday = lastMonth.toLocaleDateString('en-CA')
 
     migrationResponse = await updateMigratedOrganisation(
       organisationDetails.refNo,
@@ -54,8 +54,22 @@ describe('Report only shows from accreditation validFrom date — exporter @vali
 
     await DashboardPage.selectTableLink(1, 1)
     await WasteRecordsPage.manageReportsLink()
+
+    // wait for heading text for the page to load
+    await ReportsPage.headingText()
     const activeReports = await ReportsPage.getActiveNumberOfRows()
-    expect(activeReports).toBe(1)
+
+    // Edge case when it's in January, no reports are expected
+    if (now.getMonth() === 0) {
+      expect(activeReports).toBe(0)
+    } else {
+      expect(activeReports).toBe(1)
+      const monthYear = lastMonth.toLocaleDateString('en-US', {
+        month: 'long',
+        year: 'numeric'
+      })
+      expect(await ReportsPage.getActivePeriodLabel(1)).toBe(monthYear)
+    }
 
     await HomePage.signOut()
     await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))

--- a/test/specs/report.accreditation.date.e2e.js
+++ b/test/specs/report.accreditation.date.e2e.js
@@ -1,0 +1,63 @@
+import { browser, expect } from '@wdio/globals'
+import DefraIdStubPage from 'page-objects/defra.id.stub.page.js'
+import HomePage from 'page-objects/homepage.js'
+import DashboardPage from '../page-objects/dashboard.page.js'
+import WasteRecordsPage from '../page-objects/waste.records.page.js'
+import {
+  seedOverseasSites,
+  createAndRegisterDefraIdUser,
+  createLinkedOrganisation,
+  linkDefraIdUser,
+  updateMigratedOrganisation
+} from '../support/apicalls.js'
+import ReportsPage from 'page-objects/reports/reports.page.js'
+
+describe('Report only shows from accreditation validFrom date — exporter @validFromReport', () => {
+  const regNumber = 'E25SR500020912PA'
+  const accNumber = 'E-ACC12245PA'
+
+  let organisationDetails
+  let migrationResponse
+  let user
+
+  it('displays active report as of this month only @validFromReport', async () => {
+    organisationDetails = await createLinkedOrganisation([
+      {
+        material: 'Paper or board (R3)',
+        wasteProcessingType: 'Exporter'
+      }
+    ])
+
+    const dateToday = new Date(
+      new Date().setMonth(new Date().getMonth() - 1)
+    ).toLocaleDateString('en-CA')
+
+    migrationResponse = await updateMigratedOrganisation(
+      organisationDetails.refNo,
+      [{ regNumber, accNumber, status: 'approved' }],
+      undefined,
+      dateToday
+    )
+
+    await seedOverseasSites(organisationDetails.refNo)
+
+    user = await createAndRegisterDefraIdUser(migrationResponse.email)
+    await linkDefraIdUser(
+      organisationDetails.refNo,
+      user.userId,
+      migrationResponse.email
+    )
+
+    await HomePage.openStart()
+    await HomePage.clickStartNow()
+    await DefraIdStubPage.loginViaEmail(migrationResponse.email)
+
+    await DashboardPage.selectTableLink(1, 1)
+    await WasteRecordsPage.manageReportsLink()
+    const activeReports = await ReportsPage.getActiveNumberOfRows()
+    expect(activeReports).toBe(1)
+
+    await HomePage.signOut()
+    await expect(browser).toHaveTitle(expect.stringContaining('Signed out'))
+  })
+})

--- a/test/support/apicalls.js
+++ b/test/support/apicalls.js
@@ -176,7 +176,8 @@ export async function createLinkedOrganisation(dataRows) {
 export async function updateMigratedOrganisation(
   orgId,
   updateDataRows,
-  submittedToRegulator
+  submittedToRegulator,
+  validFrom = '2026-01-01'
 ) {
   const authClient = new AuthClient()
   const eprBackend = new EprBackend()
@@ -216,7 +217,7 @@ export async function updateMigratedOrganisation(
   for (let i = 0; i < updateDataRows.length; i++) {
     const orgUpdateData = updateDataRows[i]
     data.registrations[i].status = orgUpdateData.status
-    data.registrations[i].validFrom = '2026-01-01'
+    data.registrations[i].validFrom = validFrom
     data.registrations[i].validTo = `${currentYear + 1}-01-01`
     data.registrations[i].registrationNumber = orgUpdateData.regNumber
     data.registrations[i].statusHistory = [
@@ -258,7 +259,7 @@ export async function updateMigratedOrganisation(
       const j = accreditationIndex
       data.registrations[i].accreditationId = data.accreditations[j].id
       data.accreditations[j].status = orgUpdateData.status
-      data.accreditations[j].validFrom = '2026-01-01'
+      data.accreditations[j].validFrom = validFrom
       data.accreditations[j].validTo = `${currentYear + 1}-01-01`
       data.accreditations[j].statusHistory = [
         ...(data.accreditations[j].statusHistory || []),
@@ -331,7 +332,7 @@ export async function updateMigratedOrganisation(
     JSON.stringify(payload),
     authClient.authHeader()
   )
-  expect(response.statusCode).toBe(200)
+  await assertSuccessResponse(response, `PUT /v1/organisations/${orgId}`)
 
   return { email, registrationIds, accreditationIds }
 }


### PR DESCRIPTION
Ticket: [PAE-1737](https://eaflood.atlassian.net/browse/PAE-1737)
## Description

Only display reports required from accreditation validFrom date rather than from the beginning of the year.

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1737]: https://eaflood.atlassian.net/browse/PAE-1737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ